### PR TITLE
feat(us06): consultar disponibilidade de áreas comuns

### DIFF
--- a/apps/api/src/common-areas/common-areas.controller.spec.ts
+++ b/apps/api/src/common-areas/common-areas.controller.spec.ts
@@ -18,6 +18,8 @@ describe('CommonAreasController', () => {
     createCommonArea: jest.fn(),
     updateCommonArea: jest.fn(),
     deleteCommonArea: jest.fn(),
+    checkAvailability: jest.fn(),
+    getBusyDays: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -104,6 +106,39 @@ describe('CommonAreasController', () => {
       const result = await controller.update('area-id', dto as any, mockAuthRequest as any);
 
       expect(service.updateCommonArea).toHaveBeenCalledWith('area-id', dto, {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getBusyDays', () => {
+    it('should call getBusyDays with correct params', async () => {
+      const expected = { commonAreaId: 'area-id', year: 2026, month: 6, busyDates: ['2026-06-15'] };
+      mockService.getBusyDays.mockResolvedValue(expected);
+
+      const result = await controller.getBusyDays('area-id', '2026', '6', mockAuthRequest as any);
+
+      expect(service.getBusyDays).toHaveBeenCalledWith('area-id', 2026, 6, {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('checkAvailability', () => {
+    it('should call checkAvailability with correct params', async () => {
+      const query = { date: '2026-06-15', startTime: '10:00', endTime: '12:00' };
+      const expected = { available: true, conflicts: [] };
+      mockService.checkAvailability.mockResolvedValue(expected);
+
+      const result = await controller.checkAvailability('area-id', query as any, mockAuthRequest as any);
+
+      expect(service.checkAvailability).toHaveBeenCalledWith('area-id', query, {
         role: 'ADMIN',
         condominiumId: 'condo-id',
         userId: 'admin-id',

--- a/apps/api/src/common-areas/common-areas.controller.ts
+++ b/apps/api/src/common-areas/common-areas.controller.ts
@@ -31,12 +31,15 @@ import { DomainExceptionFilter } from '../common/filters/domain-exception.filter
 import { CommonAreasService } from './common-areas.service';
 import { CreateCommonAreaDto } from './dto/create-common-area.dto';
 import { UpdateCommonAreaDto } from './dto/update-common-area.dto';
+import { AvailabilityQueryDto } from './dto/availability-query.dto';
 import {
   CommonAreaListOutput,
   CommonAreaDetailOutput,
   CommonAreaCreatedOutput,
   CommonAreaUpdatedOutput,
   CommonAreaDeletedOutput,
+  AvailabilityOutput,
+  BusyDaysOutput,
 } from './interfaces/common-areas.interface';
 
 interface AuthRequest {
@@ -118,6 +121,63 @@ export class CommonAreasController {
     @Request() req: AuthRequest,
   ): Promise<CommonAreaDetailOutput> {
     return this.commonAreasService.getCommonAreaById(id, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Get(':id/busy-days')
+  @ApiOperation({
+    summary: 'US06 - Listar dias ocupados no mês',
+    description: `
+      **[US06]** Retorna os dias do mês que possuem reservas para uma área comum.
+      
+      **Acesso:** Administradores (ADMIN) e Moradores (RESIDENT)
+    `,
+  })
+  @ApiParam({ name: 'id', description: 'UUID da área comum' })
+  @ApiResponse({ status: 200, description: 'Lista de dias ocupados.' })
+  async getBusyDays(
+    @Param('id') id: string,
+    @Query('year') year: string,
+    @Query('month') month: string,
+    @Request() req: AuthRequest,
+  ): Promise<BusyDaysOutput> {
+    return this.commonAreasService.getBusyDays(id, Number(year), Number(month), {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Get(':id/availability')
+  @ApiOperation({
+    summary: 'US06 - Consultar disponibilidade de área comum',
+    description: `
+      **[US06]** Consulta a disponibilidade de uma área comum em uma data específica.
+      
+      **Acesso:** Administradores (ADMIN) e Moradores (RESIDENT)
+      **Regras de negócio:** RN01, RN03, RN03.1
+      
+      Se startTime e endTime forem informados, verifica se o horário específico está disponível.
+      Caso contrário, retorna os horários de funcionamento da área.
+    `,
+  })
+  @ApiParam({ name: 'id', description: 'UUID da área comum' })
+  @ApiResponse({
+    status: 200,
+    description: 'Resultado da consulta de disponibilidade.',
+  })
+  @ApiResponse({ status: 400, description: 'Parâmetros inválidos.' })
+  @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  @ApiResponse({ status: 404, description: 'Área comum não encontrada.' })
+  async checkAvailability(
+    @Param('id') id: string,
+    @Query() query: AvailabilityQueryDto,
+    @Request() req: AuthRequest,
+  ): Promise<AvailabilityOutput> {
+    return this.commonAreasService.checkAvailability(id, query, {
       role: req.user.role,
       condominiumId: req.user.condominiumId,
       userId: req.user.sub,

--- a/apps/api/src/common-areas/common-areas.service.spec.ts
+++ b/apps/api/src/common-areas/common-areas.service.spec.ts
@@ -18,6 +18,7 @@ import {
   CommonAreaUpdatedOutput,
   CreateCommonAreaInput,
   UpdateCommonAreaInput,
+  BusyDaysOutput,
 } from './interfaces/common-areas.interface';
 
 describe('CommonAreasService', () => {
@@ -67,6 +68,7 @@ describe('CommonAreasService', () => {
     },
     reservation: {
       count: jest.fn(),
+      findMany: jest.fn(),
     },
   };
 
@@ -351,6 +353,244 @@ describe('CommonAreasService', () => {
       const result = await service.updateCommonArea('area-uuid-001', { isUnderMaintenance: true }, mockContext);
 
       expect(result.isUnderMaintenance).toBe(true);
+    });
+  });
+
+  describe('getBusyDays', () => {
+    const mockArea = { ...mockCommonArea };
+
+    it('deve retornar dias ocupados no mês', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([
+        {
+          startTime: new Date('2026-06-15T10:00:00.000Z'),
+          endTime: new Date('2026-06-15T12:00:00.000Z'),
+        },
+        {
+          startTime: new Date('2026-06-20T14:00:00.000Z'),
+          endTime: new Date('2026-06-20T16:00:00.000Z'),
+        },
+      ]);
+
+      const result = await service.getBusyDays('area-uuid-001', 2026, 6, mockContext);
+
+      expect(result.busyDates).toEqual(['2026-06-15', '2026-06-20']);
+      expect(result.year).toBe(2026);
+      expect(result.month).toBe(6);
+    });
+
+    it('deve retornar lista vazia se não houver reservas', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+
+      const result = await service.getBusyDays('area-uuid-001', 2026, 6, mockContext);
+
+      expect(result.busyDates).toEqual([]);
+    });
+
+    it('deve incluir múltiplos dias para reservas que atravessam meia-noite', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([
+        {
+          startTime: new Date('2026-06-14T22:00:00.000Z'),
+          endTime: new Date('2026-06-15T02:00:00.000Z'),
+        },
+      ]);
+
+      const result = await service.getBusyDays('area-uuid-001', 2026, 6, mockContext);
+
+      expect(result.busyDates).toContain('2026-06-14');
+      expect(result.busyDates).toContain('2026-06-15');
+    });
+
+    it('deve lançar CommonAreaNotFoundException se área não existir', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(null);
+
+      await expect(service.getBusyDays('inexistente', 2026, 6, mockContext))
+        .rejects.toThrow(CommonAreaNotFoundException);
+    });
+  });
+
+  describe('checkAvailability', () => {
+    const mockArea = {
+      ...mockCommonArea,
+      openTime: '08:00',
+      closeTime: '22:00',
+      operatingDays: '1,2,3,4,5,6,7',
+      isUnderMaintenance: false,
+    };
+
+    const mockReservations = [
+      {
+        id: 'res-1',
+        startTime: new Date('2026-06-15T14:00:00.000Z'),
+        endTime: new Date('2026-06-15T16:00:00.000Z'),
+        status: 'APPROVED',
+      },
+    ];
+
+    it('deve retornar disponível se não houver reservas conflitantes', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+
+      const result = await service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, mockContext);
+
+      expect(result.available).toBe(true);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('deve retornar não disponível se houver reserva conflitante', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue(mockReservations);
+
+      const result = await service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '15:00',
+        endTime: '17:00',
+      }, mockContext);
+
+      expect(result.available).toBe(false);
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0]).toMatchObject({
+        startTime: '14:00',
+        endTime: '16:00',
+      });
+    });
+
+    it('deve retornar disponível se reserva não conflitar (antes do início)', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+
+      const result = await service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '08:00',
+        endTime: '10:00',
+      }, mockContext);
+
+      expect(result.available).toBe(true);
+    });
+
+    it('deve retornar disponível se reserva não conflitar (depois do fim)', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+
+      const result = await service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '18:00',
+        endTime: '20:00',
+      }, mockContext);
+
+      expect(result.available).toBe(true);
+    });
+
+    it('deve lançar CommonAreaNotFoundException se área não existir', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(null);
+
+      await expect(service.checkAvailability('inexistente', {
+        date: '2026-06-15',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, mockContext)).rejects.toThrow(CommonAreaNotFoundException);
+    });
+
+    it('deve lançar TenantAccessDeniedException se área for de outro condomínio', async () => {
+      const areaOutroCondo = { ...mockArea, condominiumId: 'outro-condo' };
+      mockPrisma.commonArea.findFirst.mockResolvedValue(areaOutroCondo);
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, mockContext)).rejects.toThrow(TenantAccessDeniedException);
+    });
+
+    it('deve lançar erro se área estiver em manutenção', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue({
+        ...mockArea,
+        isUnderMaintenance: true,
+      });
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, mockContext)).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se data for fora dos dias operacionais', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue({
+        ...mockArea,
+        operatingDays: '1,2,3,4,5',
+      });
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-14',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, mockContext)).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se horário solicitado for antes da abertura', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '06:00',
+        endTime: '08:00',
+      }, mockContext)).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se horário solicitado for depois do fechamento', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '22:00',
+        endTime: '23:00',
+      }, mockContext)).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se startTime for maior ou igual a endTime', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '14:00',
+        endTime: '13:00',
+      }, mockContext)).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se RESIDENT não tiver condominiumId', async () => {
+      const contextSemCondo = { role: 'RESIDENT', condominiumId: null, userId: 'user-id' };
+
+      await expect(service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, contextSemCondo as any)).rejects.toThrow(CommonAreaAccessDeniedException);
+    });
+
+    it('deve consultar reservas com status PENDING e APPROVED', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockArea);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+
+      await service.checkAvailability('area-uuid-001', {
+        date: '2026-06-15',
+        startTime: '10:00',
+        endTime: '12:00',
+      }, mockContext);
+
+      expect(mockPrisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: { in: ['PENDING', 'APPROVED'] },
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/common-areas/common-areas.service.ts
+++ b/apps/api/src/common-areas/common-areas.service.ts
@@ -18,6 +18,9 @@ import {
   CommonAreaDeletedOutput,
   CreateCommonAreaInput,
   UpdateCommonAreaInput,
+  CheckAvailabilityInput,
+  AvailabilityOutput,
+  BusyDaysOutput,
 } from './interfaces/common-areas.interface';
 
 interface ServiceContext {
@@ -199,6 +202,156 @@ export class CommonAreasService {
     return {
       message: 'Área comum deletada com sucesso',
       id: areaId,
+    };
+  }
+
+  async getBusyDays(
+    areaId: string,
+    year: number,
+    month: number,
+    context: ServiceContext,
+  ): Promise<BusyDaysOutput> {
+    this.validateAccess(context);
+
+    const commonArea = await this.prisma.commonArea.findFirst({
+      where: { id: areaId },
+    });
+
+    if (!commonArea) {
+      throw new CommonAreaNotFoundException(areaId);
+    }
+
+    this.validateTenantAccess(commonArea.condominiumId, context.condominiumId);
+
+    const startDate = new Date(Date.UTC(year, month - 1, 1));
+    const endDate = new Date(Date.UTC(year, month, 0, 23, 59, 59, 999));
+
+    const reservations = await this.prisma.reservation.findMany({
+      where: {
+        commonAreaId: areaId,
+        status: { in: ['PENDING', 'APPROVED'] },
+        startTime: { lte: endDate },
+        endTime: { gte: startDate },
+      },
+      select: { startTime: true, endTime: true },
+    });
+
+    const busySet = new Set<string>()
+
+    for (const r of reservations) {
+      const startDate = new Date(r.startTime).toISOString().split('T')[0]
+      const endDate = new Date(r.endTime).toISOString().split('T')[0]
+      const current = new Date(startDate + 'T12:00:00Z')
+      const end = new Date(endDate + 'T12:00:00Z')
+
+      while (current <= end) {
+        busySet.add(current.toISOString().split('T')[0])
+        current.setUTCDate(current.getUTCDate() + 1)
+      }
+    }
+
+    return {
+      commonAreaId: areaId,
+      year,
+      month,
+      busyDates: Array.from(busySet).sort(),
+    };
+  }
+
+  async checkAvailability(
+    areaId: string,
+    input: CheckAvailabilityInput,
+    context: ServiceContext,
+  ): Promise<AvailabilityOutput> {
+    this.validateAccess(context);
+
+    const commonArea = await this.prisma.commonArea.findFirst({
+      where: { id: areaId },
+    });
+
+    if (!commonArea) {
+      throw new CommonAreaNotFoundException(areaId);
+    }
+
+    this.validateTenantAccess(commonArea.condominiumId, context.condominiumId);
+
+    if (commonArea.isUnderMaintenance) {
+      throw new CommonAreaValidationException([
+        'Esta área comum está em manutenção e não disponível para reservas.',
+      ]);
+    }
+
+    const requestedDate = new Date(input.date + 'T12:00:00Z');
+    const dayOfWeek = ((requestedDate.getUTCDay() + 6) % 7) + 1;
+
+    const operatingDays: number[] = typeof commonArea.operatingDays === 'string'
+      ? commonArea.operatingDays.split(',').map(Number)
+      : Array.isArray(commonArea.operatingDays)
+        ? commonArea.operatingDays.map(Number)
+        : [];
+
+    if (!operatingDays.includes(dayOfWeek)) {
+      throw new CommonAreaValidationException([
+        `Esta área não funciona no dia solicitado (dia da semana ${dayOfWeek}).`,
+      ]);
+    }
+
+    const startTime = input.startTime ?? commonArea.openTime;
+    const endTime = input.endTime ?? commonArea.closeTime;
+
+    if (startTime < commonArea.openTime) {
+      throw new CommonAreaValidationException([
+        `O horário de início (${startTime}) é antes da abertura (${commonArea.openTime}).`,
+      ]);
+    }
+
+    if (endTime > commonArea.closeTime) {
+      throw new CommonAreaValidationException([
+        `O horário de fim (${endTime}) é depois do fechamento (${commonArea.closeTime}).`,
+      ]);
+    }
+
+    if (startTime >= endTime) {
+      throw new CommonAreaValidationException([
+        'O horário de início deve ser anterior ao horário de fim.',
+      ]);
+    }
+
+    const startDateTime = new Date(`${input.date}T${startTime}:00.000Z`);
+    const endDateTime = new Date(`${input.date}T${endTime}:00.000Z`);
+
+    const conflicts = await this.prisma.reservation.findMany({
+      where: {
+        commonAreaId: areaId,
+        status: { in: ['PENDING', 'APPROVED'] },
+        startTime: { lt: endDateTime },
+        endTime: { gt: startDateTime },
+      },
+      select: {
+        startTime: true,
+        endTime: true,
+        status: true,
+      },
+      orderBy: { startTime: 'asc' },
+    });
+
+    const formatTime = (dt: Date) =>
+      `${String(dt.getUTCHours()).padStart(2, '0')}:${String(dt.getUTCMinutes()).padStart(2, '0')}`;
+
+    return {
+      available: conflicts.length === 0,
+      date: input.date,
+      commonAreaId: commonArea.id,
+      commonAreaName: commonArea.name,
+      openTime: commonArea.openTime,
+      closeTime: commonArea.closeTime,
+      startTime: input.startTime,
+      endTime: input.endTime,
+      conflicts: conflicts.map((c) => ({
+        startTime: formatTime(c.startTime),
+        endTime: formatTime(c.endTime),
+        status: c.status,
+      })),
     };
   }
 

--- a/apps/api/src/common-areas/dto/availability-query.dto.ts
+++ b/apps/api/src/common-areas/dto/availability-query.dto.ts
@@ -1,0 +1,39 @@
+import { IsString, IsNotEmpty, Matches, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AvailabilityQueryDto {
+  @ApiProperty({
+    description: 'Data para consulta (YYYY-MM-DD)',
+    example: '2026-06-15',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: 'date deve estar no formato YYYY-MM-DD',
+  })
+  date!: string;
+
+  @ApiProperty({
+    description: 'Horário de início (HH:MM)',
+    example: '10:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    message: 'startTime deve estar no formato HH:MM',
+  })
+  startTime?: string;
+
+  @ApiProperty({
+    description: 'Horário de fim (HH:MM)',
+    example: '12:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    message: 'endTime deve estar no formato HH:MM',
+  })
+  endTime?: string;
+}

--- a/apps/api/src/common-areas/interfaces/common-areas.interface.ts
+++ b/apps/api/src/common-areas/interfaces/common-areas.interface.ts
@@ -61,6 +61,35 @@ export interface UpdateCommonAreaInput {
   isUnderMaintenance?: boolean;
 }
 
+export interface AvailabilityOutput {
+  available: boolean;
+  date: string;
+  commonAreaId: string;
+  commonAreaName: string;
+  openTime: string;
+  closeTime: string;
+  startTime?: string;
+  endTime?: string;
+  conflicts: {
+    startTime: string;
+    endTime: string;
+    status: string;
+  }[];
+}
+
+export interface CheckAvailabilityInput {
+  date: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface BusyDaysOutput {
+  commonAreaId: string;
+  year: number;
+  month: number;
+  busyDates: string[];
+}
+
 export interface CreateCommonAreaValidationResult {
   isValid: boolean;
   errors: string[];

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -70,13 +70,14 @@ async function bootstrap() {
         '| US03 | Cadastrar moradores (Admin) |\n' +
         '| US03.1 | Login de morador |\n' +
         '| US04 | Cadastrar e gerenciar áreas comuns (Admin) |\n' +
-        '| US05 | Visualizar áreas comuns |\n\n' +
+        '| US05 | Visualizar áreas comuns |\n' +
+        '| US06 | Consultar disponibilidade de áreas comuns |\n\n' +
         '*Desenvolvido em NestJS + Prisma ORM + PostgreSQL (Neon.tech)*',
     )
     .setVersion('1.0')
     .addTag('auth', 'US01, US02, US03.1 - Autenticação e Registro')
     .addTag('residents', 'US03 - Gestão de Moradores (Admin only)')
-    .addTag('common-areas', 'US04, US05 - Áreas Comuns')
+    .addTag('common-areas', 'US04, US05, US06 - Áreas Comuns')
     .addBearerAuth(
       {
         type: 'http',

--- a/apps/api/swagger.json
+++ b/apps/api/swagger.json
@@ -491,11 +491,128 @@
           "common-areas"
         ]
       }
+    },
+    "/api/v1/common-areas/{id}/busy-days": {
+      "get": {
+        "description": "\n      **[US06]** Retorna os dias do mês que possuem reservas para uma área comum.\n      \n      **Acesso:** Administradores (ADMIN) e Moradores (RESIDENT)\n    ",
+        "operationId": "CommonAreasController_getBusyDays",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID da área comum",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "year",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "month",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de dias ocupados."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "US06 - Listar dias ocupados no mês",
+        "tags": [
+          "common-areas"
+        ]
+      }
+    },
+    "/api/v1/common-areas/{id}/availability": {
+      "get": {
+        "description": "\n      **[US06]** Consulta a disponibilidade de uma área comum em uma data específica.\n      \n      **Acesso:** Administradores (ADMIN) e Moradores (RESIDENT)\n      **Regras de negócio:** RN01, RN03, RN03.1\n      \n      Se startTime e endTime forem informados, verifica se o horário específico está disponível.\n      Caso contrário, retorna os horários de funcionamento da área.\n    ",
+        "operationId": "CommonAreasController_checkAvailability",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID da área comum",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date",
+            "required": true,
+            "in": "query",
+            "description": "Data para consulta (YYYY-MM-DD)",
+            "schema": {
+              "example": "2026-06-15",
+              "type": "string"
+            }
+          },
+          {
+            "name": "startTime",
+            "required": false,
+            "in": "query",
+            "description": "Horário de início (HH:MM)",
+            "schema": {
+              "example": "10:00",
+              "type": "string"
+            }
+          },
+          {
+            "name": "endTime",
+            "required": false,
+            "in": "query",
+            "description": "Horário de fim (HH:MM)",
+            "schema": {
+              "example": "12:00",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resultado da consulta de disponibilidade."
+          },
+          "400": {
+            "description": "Parâmetros inválidos."
+          },
+          "401": {
+            "description": "Não autenticado."
+          },
+          "404": {
+            "description": "Área comum não encontrada."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "US06 - Consultar disponibilidade de área comum",
+        "tags": [
+          "common-areas"
+        ]
+      }
     }
   },
   "info": {
     "title": "🚀 Reserva Aí! - API de Gestão de Condomínios",
-    "description": "## 📝 Sobre o Projeto\nO **Reserva Aí!** é uma solução completa para a modernização da gestão de condomínios.\n\n### 🛠️ Guia de Uso\n1. **Autenticação:** Após login, use o token JWT no header Authorization: `Bearer <token>`\n2. **Isolamento (Multi-tenant):** Dados isolados por condomínio (RN01)\n3. **Roles:** ADMIN (administrador), RESIDENT (morador), SUPER_ADMIN\n\n### 🔐 Segurança e Permissões\n| Role | Acesso |\n|------|--------|\n| ADMIN | CRUD completo: condomínio, moradores e áreas |\n| RESIDENT | READ: áreas comuns; BOOK: reservas |\n| SUPER_ADMIN | Global (sem condomínio vinculado) |\n\n### 📋 User Stories Implementadas\n| US | Descrição |\n|----|----------|\n| US01 | Criar conta e registrar condomínio |\n| US02 | Login e gerenciar dados do condomínio |\n| US03 | Cadastrar moradores (Admin) |\n| US03.1 | Login de morador |\n| US04 | Cadastrar e gerenciar áreas comuns (Admin) |\n| US05 | Visualizar áreas comuns |\n\n*Desenvolvido em NestJS + Prisma ORM + PostgreSQL (Neon.tech)*",
+    "description": "## 📝 Sobre o Projeto\nO **Reserva Aí!** é uma solução completa para a modernização da gestão de condomínios.\n\n### 🛠️ Guia de Uso\n1. **Autenticação:** Após login, use o token JWT no header Authorization: `Bearer <token>`\n2. **Isolamento (Multi-tenant):** Dados isolados por condomínio (RN01)\n3. **Roles:** ADMIN (administrador), RESIDENT (morador), SUPER_ADMIN\n\n### 🔐 Segurança e Permissões\n| Role | Acesso |\n|------|--------|\n| ADMIN | CRUD completo: condomínio, moradores e áreas |\n| RESIDENT | READ: áreas comuns; BOOK: reservas |\n| SUPER_ADMIN | Global (sem condomínio vinculado) |\n\n### 📋 User Stories Implementadas\n| US | Descrição |\n|----|----------|\n| US01 | Criar conta e registrar condomínio |\n| US02 | Login e gerenciar dados do condomínio |\n| US03 | Cadastrar moradores (Admin) |\n| US03.1 | Login de morador |\n| US04 | Cadastrar e gerenciar áreas comuns (Admin) |\n| US05 | Visualizar áreas comuns |\n| US06 | Consultar disponibilidade de áreas comuns |\n\n*Desenvolvido em NestJS + Prisma ORM + PostgreSQL (Neon.tech)*",
     "version": "1.0",
     "contact": {}
   },
@@ -510,7 +627,7 @@
     },
     {
       "name": "common-areas",
-      "description": "US04, US05 - Áreas Comuns"
+      "description": "US04, US05, US06 - Áreas Comuns"
     }
   ],
   "servers": [],

--- a/apps/web/src/modules/admin/routes.ts
+++ b/apps/web/src/modules/admin/routes.ts
@@ -7,6 +7,7 @@ import CondominiumSettingsPage from './pages/CondominiumSettingsPage.vue'
 import ResidentsListPage from '@/modules/residents/pages/ResidentsListPage.vue'
 import ResidentsDetailPage from '@/modules/residents/pages/ResidentsDetailPage.vue'
 import ResidentsFormPage from '@/modules/residents/pages/ResidentsFormPage.vue'
+import AvailabilityPage from '@/modules/resident/pages/AvailabilityPage.vue'
 
 export const adminRoutes = [
   {
@@ -63,5 +64,10 @@ export const adminRoutes = [
     path: '/condominium/settings',
     name: 'admin-settings',
     component: CondominiumSettingsPage,
+  },
+  {
+    path: '/condominium/availability',
+    name: 'admin-availability',
+    component: AvailabilityPage,
   },
 ]

--- a/apps/web/src/modules/resident/pages/AvailabilityPage.vue
+++ b/apps/web/src/modules/resident/pages/AvailabilityPage.vue
@@ -1,49 +1,469 @@
 <template>
   <div class="flex min-h-screen bg-surface text-on-surface">
-    <SideNavBar 
-      role="RESIDENT" 
+    <SideNavBar
+      :role="userRole"
       :userName="userName"
       :collapsed="sidebarCollapsed"
       @toggle-collapse="toggleCollapse"
       @logout="handleLogout"
       @cta-click="handleQuickAction"
-      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" 
+      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']"
     />
+
     <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
-      <TopAppBar 
-        :userName="userName" 
-        userRole="RESIDENT"
-        @toggle-sidebar="sidebarOpen = !sidebarOpen" 
+      <TopAppBar
+        :userName="userName"
+        :userRole="userRole"
+        @toggle-sidebar="sidebarOpen = !sidebarOpen"
       />
-      <div class="flex-1 p-4 md:p-6 lg:p-8 flex flex-col items-center justify-center text-center">
-        <div class="w-20 h-20 bg-sky-100 rounded-full flex items-center justify-center mb-6">
-          <span class="material-symbols-outlined text-4xl text-sky-500">construction</span>
+
+      <div class="flex-1 p-4 md:p-6 lg:p-8">
+        <div class="mb-6 md:mb-8">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
+              <span class="material-symbols-outlined text-primary">calendar_month</span>
+            </div>
+            <h1 class="text-2xl font-bold text-cyan-900">Consultar Disponibilidade</h1>
+          </div>
+          <p class="text-slate-500 ml-[52px]">Selecione uma área e um dia para ver os horários livres</p>
         </div>
-        <h1 class="text-2xl font-bold text-cyan-900 mb-2">Disponibilidade</h1>
-        <p class="text-slate-500 max-w-md mb-2">Esta funcionalidade está em desenvolvimento.</p>
-        <span class="inline-flex items-center gap-1 px-3 py-1 bg-sky-50 text-sky-700 rounded-full text-sm font-medium">US06 - Consultar disponibilidade de áreas</span>
+
+        <div v-if="loadingAreas" class="flex items-center justify-center py-12">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </div>
+
+        <template v-else>
+          <!-- Area Selector -->
+          <div class="bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm mb-6">
+            <div class="flex items-center gap-4">
+              <div class="flex-1">
+                <label class="block text-sm font-medium text-slate-700 mb-1.5">Área Comum</label>
+                <select
+                  v-model="selectedAreaId"
+                  @change="onAreaChange"
+                  class="w-full max-w-xs px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                >
+                  <option value="" disabled>Selecione uma área</option>
+                  <option v-for="area in areas" :key="area.id" :value="area.id">
+                    {{ area.name }}
+                  </option>
+                </select>
+              </div>
+
+              <div v-if="selectedArea" class="text-sm text-slate-500 flex items-center gap-4">
+                <span class="flex items-center gap-1">
+                  <span class="material-symbols-outlined text-[16px]">schedule</span>
+                  {{ selectedArea.openTime }} - {{ selectedArea.closeTime }}
+                </span>
+                <span v-if="selectedArea.capacity" class="flex items-center gap-1">
+                  <span class="material-symbols-outlined text-[16px]">group</span>
+                  {{ selectedArea.capacity }} pessoas
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <!-- Calendar -->
+            <div class="xl:col-span-2 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <div class="flex items-center justify-between mb-4">
+                <button @click="prevMonth" class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500">
+                  <span class="material-symbols-outlined">chevron_left</span>
+                </button>
+                <span class="font-bold text-cyan-900">{{ monthLabel }}</span>
+                <button @click="nextMonth" class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500">
+                  <span class="material-symbols-outlined">chevron_right</span>
+                </button>
+              </div>
+
+              <div class="grid grid-cols-7 gap-1 mb-1">
+                <div v-for="day in dayLabels" :key="day" class="text-center text-xs font-semibold text-slate-400 py-1.5">
+                  {{ day }}
+                </div>
+              </div>
+
+              <div class="grid grid-cols-7 gap-1">
+                <div
+                  v-for="(day, idx) in calendarDays"
+                  :key="idx"
+                  @click="onDayClick(day)"
+                  class="relative rounded-lg flex flex-col items-center justify-center text-sm transition-all cursor-pointer min-h-[44px]"
+                  :class="dayCellClass(day)"
+                >
+                  <span class="font-medium leading-none" :class="dayTextClass(day)">{{ day.number }}</span>
+                  <span v-if="day.type === 'current' && !day.past && day.isOperating && selectedAreaId && day.dateStr === selectedDate" class="text-[10px] mt-0.5 font-medium text-white/80">
+                    {{ selectedArea?.openTime }}
+                  </span>
+                </div>
+              </div>
+
+              <div v-if="selectedArea" class="mt-4 pt-3 border-t border-slate-100 flex items-center gap-4 text-xs">
+                <span class="flex items-center gap-1.5">
+                  <span class="w-3 h-3 rounded-sm bg-emerald-400 inline-block"></span>
+                  Disponível
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <span class="w-3 h-3 rounded-sm bg-red-400 inline-block"></span>
+                  Ocupado
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <span class="w-3 h-3 rounded-sm bg-slate-100 border border-slate-200 inline-block"></span>
+                  Fechado
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <span class="w-3 h-3 rounded-sm bg-primary/20 inline-block"></span>
+                  Selecionado
+                </span>
+              </div>
+            </div>
+
+            <!-- Result Panel -->
+            <div class="bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <template v-if="!selectedAreaId">
+                <div class="flex flex-col items-center justify-center h-full py-8 text-center">
+                  <span class="material-symbols-outlined text-4xl text-slate-300 mb-3">pin_drop</span>
+                  <p class="text-slate-400 text-sm">Escolha uma área comum</p>
+                </div>
+              </template>
+
+              <template v-else-if="!selectedDate">
+                <div class="flex flex-col items-center justify-center h-full py-8 text-center">
+                  <span class="material-symbols-outlined text-4xl text-slate-300 mb-3">calendar_month</span>
+                  <p class="text-slate-400 text-sm">Clique num dia do calendário</p>
+                </div>
+              </template>
+
+              <template v-if="checking">
+                <div class="flex items-center justify-center py-8">
+                  <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+                </div>
+              </template>
+
+              <template v-if="checkError">
+                <div class="text-center py-4">
+                  <span class="material-symbols-outlined text-3xl text-red-300 mb-2">error_outline</span>
+                  <p class="text-sm text-red-600">{{ checkError }}</p>
+                </div>
+              </template>
+
+              <template v-if="result">
+                <h3 class="font-bold text-cyan-900 text-lg mb-1">{{ formatDate(result.date) }}</h3>
+                <p class="text-xs text-slate-400 mb-4">{{ result.openTime }} - {{ result.closeTime }}</p>
+
+                <!-- Status Banner -->
+                <div v-if="result.available" class="bg-emerald-50 border border-emerald-200 rounded-xl px-4 py-3 text-center mb-4">
+                  <span class="material-symbols-outlined text-2xl text-emerald-500">check_circle</span>
+                  <p class="font-bold text-emerald-800 text-sm">Disponível o dia todo</p>
+                </div>
+                <div v-else class="bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-center mb-4">
+                  <span class="material-symbols-outlined text-2xl text-red-400">block</span>
+                  <p class="font-bold text-red-800 text-sm">{{ result.conflicts.length }} reserva{{ result.conflicts.length > 1 ? 's' : '' }} no dia</p>
+                </div>
+
+                <!-- Timeline -->
+                <div class="space-y-1">
+                  <div
+                    v-for="(slot, idx) in timeSlots"
+                    :key="idx"
+                    class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm"
+                    :class="slot.available ? 'bg-emerald-50/50' : 'bg-red-50/50'"
+                  >
+                    <span
+                      class="material-symbols-outlined text-[18px]"
+                      :class="slot.available ? 'text-emerald-400' : 'text-red-400'"
+                    >
+                      {{ slot.available ? 'check_circle' : 'block' }}
+                    </span>
+                    <span class="font-medium" :class="slot.available ? 'text-emerald-700' : 'text-red-700'">
+                      {{ slot.start }} - {{ slot.end }}
+                    </span>
+                    <span v-if="!slot.available" class="text-xs text-red-400 ml-auto">
+                      {{ statusLabel(slot.status) }}
+                    </span>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </template>
       </div>
     </main>
+
     <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
   </div>
 </template>
+
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
 import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
 import { authService } from '@/modules/auth/services/auth.service'
 import { http } from '@/api/http'
 import { useSidebar } from '@/modules/shared/composables/useSidebar'
+
+interface CommonArea {
+  id: string
+  name: string
+  description: string | null
+  capacity: number | null
+  openTime: string
+  closeTime: string
+  operatingDays: number[] | null
+  requiresApproval: boolean
+  icon: string | null
+  isUnderMaintenance: boolean
+}
+
+interface Conflict {
+  startTime: string
+  endTime: string
+  status: string
+}
+
+interface AvailabilityResult {
+  available: boolean
+  date: string
+  commonAreaId: string
+  commonAreaName: string
+  openTime: string
+  closeTime: string
+  startTime?: string
+  endTime?: string
+  conflicts: Conflict[]
+}
+
+interface TimeSlot {
+  start: string
+  end: string
+  available: boolean
+  status?: string
+}
+
+interface CalendarDay {
+  type: 'prev' | 'current' | 'next'
+  number: number
+  dateStr: string
+  isToday: boolean
+  past: boolean
+  isOperating: boolean
+}
+
 const router = useRouter()
+const route = useRoute()
+const userRole = computed(() => route.path.startsWith('/condominium') ? 'ADMIN' : 'RESIDENT')
 const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
+
 const user = authService.getUser()
 const userName = ref(user?.name || '')
+
+const areas = ref<CommonArea[]>([])
+const loadingAreas = ref(true)
+const selectedAreaId = ref('')
+const selectedDate = ref('')
+const checking = ref(false)
+const checkError = ref<string | null>(null)
+const result = ref<AvailabilityResult | null>(null)
+
+const currentMonth = ref(new Date().getMonth())
+const currentYear = ref(new Date().getFullYear())
+const busyDates = ref<Set<string>>(new Set())
+
+const dayLabels = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
+
+const selectedArea = computed(() => {
+  if (!selectedAreaId.value) return null
+  return areas.value.find((a) => a.id === selectedAreaId.value) || null
+})
+
+const monthLabel = computed(() => {
+  const d = new Date(currentYear.value, currentMonth.value, 1)
+  return d.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })
+})
+
+const operatingDaysSet = computed(() => {
+  const area = selectedArea.value
+  if (!area?.operatingDays) return new Set<number>()
+  const days = Array.isArray(area.operatingDays) ? area.operatingDays : []
+  const map: Record<number, number> = { 0: 7, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6 }
+  return new Set(days.map((d) => map[d] ?? d))
+})
+
+const timeSlots = computed<TimeSlot[]>(() => {
+  if (!result.value) return []
+  const { openTime, closeTime, conflicts } = result.value
+
+  const slots: TimeSlot[] = []
+  let cursor = openTime
+
+  const sorted = [...conflicts].sort((a, b) => a.startTime.localeCompare(b.startTime))
+
+  for (const c of sorted) {
+    if (cursor < c.startTime) {
+      slots.push({ start: cursor, end: c.startTime, available: true })
+    }
+    slots.push({ start: c.startTime, end: c.endTime, available: false, status: c.status })
+    cursor = c.endTime > cursor ? c.endTime : cursor
+  }
+
+  if (cursor < closeTime) {
+    slots.push({ start: cursor, end: closeTime, available: true })
+  }
+
+  return slots
+})
+
+const calendarDays = computed(() => {
+  const year = currentYear.value
+  const month = currentMonth.value
+  const todayDate = new Date()
+
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+  const startPad = firstDay.getDay()
+  const daysInMonth = lastDay.getDate()
+  const daysInPrev = new Date(year, month, 0).getDate()
+
+  const days: CalendarDay[] = []
+
+  for (let i = startPad - 1; i >= 0; i--) {
+    const dt = new Date(year, month - 1, daysInPrev - i)
+    days.push({ type: 'prev', number: daysInPrev - i, dateStr: fmtDate(dt), isToday: false, past: true, isOperating: false })
+  }
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dt = new Date(year, month, day)
+    const ds = fmtDate(dt)
+    const isToday = ds === fmtDate(todayDate)
+    const past = dt < new Date(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate())
+    const dow = ((dt.getDay() + 6) % 7) + 1
+    days.push({ type: 'current', number: day, dateStr: ds, isToday, past, isOperating: operatingDaysSet.value.has(dow) })
+  }
+
+  const remaining = 42 - days.length
+  for (let day = 1; day <= remaining; day++) {
+    const dt = new Date(year, month + 1, day)
+    days.push({ type: 'next', number: day, dateStr: fmtDate(dt), isToday: false, past: false, isOperating: false })
+  }
+
+  return days
+})
+
+function fmtDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function dayCellClass(day: CalendarDay): Record<string, boolean> {
+  const isSel = selectedDate.value === day.dateStr
+  const isBusy = busyDates.value.has(day.dateStr)
+  const isFree = day.type === 'current' && !day.past && day.isOperating && !isBusy
+
+  return {
+    'opacity-20 cursor-default': day.type !== 'current' || (day.type === 'current' && day.past),
+    'bg-slate-100 text-slate-400 cursor-default': day.type === 'current' && !day.past && !day.isOperating,
+    'bg-emerald-400 text-white hover:brightness-110': isFree && !isSel,
+    'bg-red-400 text-white hover:brightness-110': isBusy && !isSel,
+    'bg-primary text-white ring-2 ring-primary/40': isSel,
+  }
+}
+
+function dayTextClass(day: CalendarDay): string {
+  if (day.dateStr === selectedDate.value) return 'text-white'
+  if (day.type === 'current' && !day.past && day.isOperating) return 'text-white'
+  return ''
+}
+
+function prevMonth() {
+  if (currentMonth.value === 0) { currentMonth.value = 11; currentYear.value-- }
+  else { currentMonth.value-- }
+  if (selectedAreaId.value) fetchBusyDays()
+}
+
+function nextMonth() {
+  if (currentMonth.value === 11) { currentMonth.value = 0; currentYear.value++ }
+  else { currentMonth.value++ }
+  if (selectedAreaId.value) fetchBusyDays()
+}
+
+function onDayClick(day: CalendarDay) {
+  if (day.type !== 'current' || day.past || !day.isOperating || !selectedAreaId.value) return
+  selectedDate.value = day.dateStr
+  checkAvailability()
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T12:00:00Z')
+  return d.toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: 'long' })
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = { PENDING: 'Pendente', APPROVED: 'Confirmada', CANCELED: 'Cancelada', REJECTED: 'Rejeitada' }
+  return map[status] || status
+}
+
+async function fetchBusyDays() {
+  if (!selectedAreaId.value) return
+  try {
+    const res = await http.get(`/common-areas/${selectedAreaId.value}/busy-days`, {
+      params: { year: currentYear.value, month: currentMonth.value + 1 },
+    })
+    busyDates.value = new Set(res.data.data.busyDates)
+  } catch {
+    busyDates.value = new Set()
+  }
+}
+
+function onAreaChange() {
+  selectedDate.value = ''
+  result.value = null
+  checkError.value = null
+  busyDates.value = new Set()
+  fetchBusyDays()
+}
+
+async function checkAvailability() {
+  checkError.value = null
+  result.value = null
+  checking.value = true
+  try {
+    const res = await http.get(`/common-areas/${selectedAreaId.value}/availability`, {
+      params: { date: selectedDate.value },
+    })
+    result.value = res.data.data as AvailabilityResult
+  } catch (err: any) {
+    checkError.value = err?.response?.data?.message || err?.message || 'Erro ao verificar disponibilidade.'
+  } finally {
+    checking.value = false
+  }
+}
+
+async function fetchAreas() {
+  loadingAreas.value = true
+  try {
+    const res = await http.get('/common-areas', { params: { limit: 50 } })
+    areas.value = ((res.data.data as any).commonAreas as CommonArea[]).filter((a) => !a.isUnderMaintenance)
+  } catch {
+    checkError.value = 'Não foi possível carregar as áreas.'
+  } finally {
+    loadingAreas.value = false
+  }
+}
+
 const handleQuickAction = () => {}
+
 const handleLogout = async () => {
   try { await http.post('/auth/logout') } catch {}
   authService.logout()
   router.push('/')
 }
 
+onMounted(() => {
+  fetchAreas()
+})
 </script>
+
+<style scoped>
+.material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+</style>

--- a/apps/web/src/modules/resident/pages/CommonAreasListPage.spec.ts
+++ b/apps/web/src/modules/resident/pages/CommonAreasListPage.spec.ts
@@ -125,7 +125,7 @@ describe('CommonAreasListPage', () => {
     await wrapper.vm.$nextTick()
 
     const cards = wrapper.findAll('.cursor-pointer')
-    await cards[0].trigger('click')
+    await cards[0]!.trigger('click')
 
     expect(mockPush).toHaveBeenCalledWith('/resident/common-areas/1')
   })

--- a/apps/web/src/modules/shared/config/menuConfig.ts
+++ b/apps/web/src/modules/shared/config/menuConfig.ts
@@ -19,6 +19,7 @@ export const menuConfig: Record<UserRole, MenuItem[]> = {
     { path: '/condominium/residents', label: 'Moradores', icon: 'group' },
     { path: '/condominium/common-areas', label: 'Áreas Comuns', icon: 'pool' },
     { path: '/condominium/reservations', label: 'Reservas', icon: 'event_available' },
+    { path: '/condominium/availability', label: 'Disponibilidade', icon: 'calendar_month' },
     { path: '/condominium/reports', label: 'Relatórios', icon: 'assessment' },
   ],
   RESIDENT: [


### PR DESCRIPTION
- Backend: endpoint GET /common-areas/:id/availability para verificar horários
- Backend: endpoint GET /common-areas/:id/busy-days para dias ocupados no mês
- Frontend: AvailabilityPage com calendário colorido e timeline de horários
- Admin: rota /condominium/availability adicionada ao menu
- Testes: 14 testes no service + 1 no controller (TDD)
- Fix: TypeScript error no CommonAreasListPage.spec.ts