### PR TITLE
feat: implementa US06-US10 (reservas) com backend TDD e frontend comp…

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { ResidentsModule } from './residents/residents.module';
 import { CommonAreasModule } from './common-areas/common-areas.module';
+import { ReservationsModule } from './reservations/reservations.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { LoggerMiddleware } from './logger/logger.middleware';
 
@@ -18,6 +19,7 @@ import { LoggerMiddleware } from './logger/logger.middleware';
     AuthModule,
     ResidentsModule,
     CommonAreasModule,
+    ReservationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -71,13 +71,15 @@ async function bootstrap() {
         '| US03.1 | Login de morador |\n' +
         '| US04 | Cadastrar e gerenciar áreas comuns (Admin) |\n' +
         '| US05 | Visualizar áreas comuns |\n' +
-        '| US06 | Consultar disponibilidade de áreas comuns |\n\n' +
+        '| US06 | Consultar disponibilidade de áreas comuns |\n' +
+        '| US07 | Realizar reserva de área comum |\n\n' +
         '*Desenvolvido em NestJS + Prisma ORM + PostgreSQL (Neon.tech)*',
     )
     .setVersion('1.0')
     .addTag('auth', 'US01, US02, US03.1 - Autenticação e Registro')
     .addTag('residents', 'US03 - Gestão de Moradores (Admin only)')
-    .addTag('common-areas', 'US04, US05, US06 - Áreas Comuns')
+    .addTag('reservations', 'US07 - Reservas')
+.addTag('common-areas', 'US04, US05, US06 - Áreas Comuns')
     .addBearerAuth(
       {
         type: 'http',

--- a/apps/api/src/reservations/dto/create-reservation.dto.ts
+++ b/apps/api/src/reservations/dto/create-reservation.dto.ts
@@ -1,0 +1,37 @@
+import { IsString, IsNotEmpty, IsOptional, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateReservationDto {
+  @ApiProperty({ description: 'UUID da área comum' })
+  @IsString()
+  @IsNotEmpty()
+  commonAreaId: string;
+
+  @ApiProperty({ description: 'Data da reserva (YYYY-MM-DD)', example: '2026-07-15' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'date deve estar no formato YYYY-MM-DD' })
+  date: string;
+
+  @ApiProperty({ description: 'Horário de início (HH:MM)', example: '10:00' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'startTime deve estar no formato HH:MM' })
+  startTime: string;
+
+  @ApiProperty({ description: 'Horário de fim (HH:MM)', example: '12:00' })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'endTime deve estar no formato HH:MM' })
+  endTime: string;
+
+  @ApiProperty({ description: 'Observações', required: false })
+  @IsString()
+  @IsOptional()
+  notes?: string;
+
+  @ApiProperty({ description: 'UUID do morador (apenas admin)', required: false })
+  @IsString()
+  @IsOptional()
+  residentId?: string;
+}

--- a/apps/api/src/reservations/exceptions/index.ts
+++ b/apps/api/src/reservations/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './reservation.exceptions';

--- a/apps/api/src/reservations/exceptions/reservation.exceptions.ts
+++ b/apps/api/src/reservations/exceptions/reservation.exceptions.ts
@@ -1,0 +1,63 @@
+import { HttpStatus } from '@nestjs/common';
+import { DomainException } from '../../common-areas/exceptions/common-area.exceptions';
+
+export class ReservationConflictException extends DomainException {
+  constructor() {
+    super({
+      code: 'RESERVATION_CONFLICT',
+      message: 'Já existe uma reserva neste horário para esta área.',
+      statusCode: HttpStatus.CONFLICT,
+    });
+  }
+}
+
+export class ResidentNotFoundException extends DomainException {
+  constructor() {
+    super({
+      code: 'RESIDENT_NOT_FOUND',
+      message: 'Perfil de morador não encontrado.',
+      statusCode: HttpStatus.NOT_FOUND,
+    });
+  }
+}
+
+export class ResidentCannotBookException extends DomainException {
+  constructor() {
+    super({
+      code: 'RESIDENT_CANNOT_BOOK',
+      message: 'Este morador não pode realizar reservas.',
+      statusCode: HttpStatus.FORBIDDEN,
+    });
+  }
+}
+
+export class ReservationNotFoundException extends DomainException {
+  constructor(id: string) {
+    super({
+      code: 'RESERVATION_NOT_FOUND',
+      message: `Reserva com ID ${id} não encontrada.`,
+      statusCode: HttpStatus.NOT_FOUND,
+      details: { reservationId: id },
+    });
+  }
+}
+
+export class ReservationAlreadyCanceledException extends DomainException {
+  constructor() {
+    super({
+      code: 'RESERVATION_ALREADY_CANCELED',
+      message: 'Esta reserva já foi cancelada.',
+      statusCode: HttpStatus.CONFLICT,
+    });
+  }
+}
+
+export class ReservationAccessDeniedException extends DomainException {
+  constructor() {
+    super({
+      code: 'RESERVATION_ACCESS_DENIED',
+      message: 'Você não tem permissão para cancelar esta reserva.',
+      statusCode: HttpStatus.FORBIDDEN,
+    });
+  }
+}

--- a/apps/api/src/reservations/interfaces/reservation.interface.ts
+++ b/apps/api/src/reservations/interfaces/reservation.interface.ts
@@ -1,0 +1,51 @@
+export interface CreateReservationInput {
+  commonAreaId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  notes?: string;
+  residentId?: string;
+}
+
+export interface ListReservationsQuery {
+  page?: number;
+  limit?: number;
+  status?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface ReservationListOutput {
+  reservations: ReservationOutput[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface ReservationOutput {
+  id: string;
+  residentId: string;
+  commonAreaId: string;
+  startTime: Date;
+  endTime: Date;
+  status: string;
+  notes: string | null;
+  canceledById: string | null;
+  canceledAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  commonArea?: {
+    id: string;
+    name: string;
+    icon: string | null;
+    capacity: number | null;
+  };
+  resident?: {
+    id: string;
+    user: {
+      name: string;
+      email: string;
+    };
+  };
+}

--- a/apps/api/src/reservations/reservations.controller.spec.ts
+++ b/apps/api/src/reservations/reservations.controller.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ReservationsController } from './reservations.controller';
+import { ReservationsService } from './reservations.service';
+
+describe('ReservationsController', () => {
+  let controller: ReservationsController;
+  let service: ReservationsService;
+
+  const mockAuthRequest = {
+    user: { sub: 'user-id', email: 'user@test.com', role: 'RESIDENT', condominiumId: 'condo-id' },
+  };
+
+  const mockService = {
+    createReservation: jest.fn(),
+    listReservations: jest.fn(),
+    cancelReservation: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReservationsController],
+      providers: [
+        { provide: ReservationsService, useValue: mockService },
+        { provide: JwtService, useValue: { verifyAsync: jest.fn() } },
+        JwtAuthGuard,
+      ],
+    }).compile();
+
+    controller = module.get<ReservationsController>(ReservationsController);
+    service = module.get<ReservationsService>(ReservationsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should call listReservations with correct params', async () => {
+      const expected = { reservations: [], total: 0 };
+      mockService.listReservations.mockResolvedValue(expected);
+
+      const result = await controller.findAll(mockAuthRequest as any, 10, 1, 'PENDING', undefined, undefined);
+
+      expect(service.listReservations).toHaveBeenCalledWith({
+        role: 'RESIDENT',
+        condominiumId: 'condo-id',
+        userId: 'user-id',
+      }, { page: 1, limit: 10, status: 'PENDING', from: undefined, to: undefined });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('cancel', () => {
+    it('should call cancelReservation with correct params', async () => {
+      const expected = { id: 'res-id', status: 'CANCELED' };
+      mockService.cancelReservation.mockResolvedValue(expected);
+
+      const result = await controller.cancel('res-id', mockAuthRequest as any);
+
+      expect(service.cancelReservation).toHaveBeenCalledWith('res-id', {
+        role: 'RESIDENT',
+        condominiumId: 'condo-id',
+        userId: 'user-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('create', () => {
+    const dto = {
+      commonAreaId: 'area-id',
+      date: '2026-07-15',
+      startTime: '10:00',
+      endTime: '12:00',
+    };
+
+    it('should call createReservation with correct params', async () => {
+      const expected = { id: 'res-id', status: 'PENDING' };
+      mockService.createReservation.mockResolvedValue(expected);
+
+      const result = await controller.create(dto as any, mockAuthRequest as any);
+
+      expect(service.createReservation).toHaveBeenCalledWith(dto, {
+        role: 'RESIDENT',
+        condominiumId: 'condo-id',
+        userId: 'user-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/apps/api/src/reservations/reservations.controller.ts
+++ b/apps/api/src/reservations/reservations.controller.ts
@@ -1,0 +1,136 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  UseFilters,
+  Request,
+  HttpCode,
+  HttpStatus,
+  DefaultValuePipe,
+  ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TransformInterceptor } from '../common/interceptors/transform.interceptor';
+import { DomainExceptionFilter } from '../common/filters/domain-exception.filter';
+import { ReservationsService } from './reservations.service';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+import { ReservationOutput, ReservationListOutput } from './interfaces/reservation.interface';
+
+interface AuthRequest {
+  user: {
+    sub: string;
+    email: string;
+    role: string;
+    condominiumId: string;
+  };
+}
+
+@ApiTags('reservations')
+@ApiBearerAuth()
+@Controller('reservations')
+@UseGuards(JwtAuthGuard)
+@UseInterceptors(TransformInterceptor)
+@UseFilters(DomainExceptionFilter)
+export class ReservationsController {
+  constructor(private readonly reservationsService: ReservationsService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'US09/US10 - Listar reservas',
+    description: `
+      **[US09/US10]** Lista reservas.
+
+      **Acesso:**
+      - RESIDENT: lista apenas as próprias reservas
+      - ADMIN: lista todas as reservas do condomínio
+    `,
+  })
+  @ApiResponse({ status: 200, description: 'Lista de reservas.' })
+  async findAll(
+    @Request() req: AuthRequest,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('status') status?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ): Promise<ReservationListOutput> {
+    return this.reservationsService.listReservations({
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    }, { page, limit, status, from, to });
+  }
+
+  @Patch(':id/cancel')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'US08 - Cancelar reserva',
+    description: `
+      **[US08]** Cancela uma reserva.
+      
+      **Acesso:**
+      - RESIDENT: cancela apenas as próprias reservas
+      - ADMIN: cancela qualquer reserva do condomínio
+      
+      Registra o ID do usuário que cancelou e a data do cancelamento (auditoria).
+    `,
+  })
+  @ApiResponse({ status: 200, description: 'Reserva cancelada com sucesso.' })
+  @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  @ApiResponse({ status: 403, description: 'Acesso negado.' })
+  @ApiResponse({ status: 404, description: 'Reserva não encontrada.' })
+  @ApiResponse({ status: 409, description: 'Reserva já cancelada.' })
+  async cancel(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<ReservationOutput> {
+    return this.reservationsService.cancelReservation(id, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'US07 - Criar uma reserva',
+    description: `
+      **[US07]** Realiza uma reserva de área comum em um período disponível.
+      
+      **Acesso:** Moradores (RESIDENT) e Administradores (ADMIN)
+      **Regras de negócio:** RN01, RN03, RN03.1
+      
+      Para RESIDENT, o residentId é obtido automaticamente do token JWT.
+      Para ADMIN, pode-se informar o residentId no body.
+    `,
+  })
+  @ApiResponse({ status: 201, description: 'Reserva criada com sucesso.' })
+  @ApiResponse({ status: 400, description: 'Dados de entrada inválidos.' })
+  @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  @ApiResponse({ status: 403, description: 'Acesso negado.' })
+  @ApiResponse({ status: 404, description: 'Área ou morador não encontrado.' })
+  @ApiResponse({ status: 409, description: 'Conflito de horário.' })
+  async create(
+    @Body() input: CreateReservationDto,
+    @Request() req: AuthRequest,
+  ): Promise<ReservationOutput> {
+    return this.reservationsService.createReservation(input, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+}

--- a/apps/api/src/reservations/reservations.module.ts
+++ b/apps/api/src/reservations/reservations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ReservationsController } from './reservations.controller';
+import { ReservationsService } from './reservations.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ReservationsController],
+  providers: [ReservationsService],
+  exports: [ReservationsService],
+})
+export class ReservationsModule {}

--- a/apps/api/src/reservations/reservations.service.spec.ts
+++ b/apps/api/src/reservations/reservations.service.spec.ts
@@ -1,0 +1,515 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { ReservationsService } from './reservations.service';
+import {
+  CommonAreaNotFoundException,
+  TenantAccessDeniedException,
+  CommonAreaValidationException,
+  CommonAreaAccessDeniedException,
+} from '../common-areas/exceptions';
+import {
+  ReservationConflictException,
+  ResidentNotFoundException,
+  ResidentCannotBookException,
+  ReservationNotFoundException,
+  ReservationAlreadyCanceledException,
+  ReservationAccessDeniedException,
+} from './exceptions';
+
+describe('ReservationsService', () => {
+  let service: ReservationsService;
+  let prismaService: PrismaService;
+
+  const mockCondoId = 'condo-uuid-123';
+  const mockUserId = 'user-uuid-456';
+  const mockResidentId = 'resident-uuid-789';
+
+  const mockContext = {
+    role: Role.RESIDENT,
+    condominiumId: mockCondoId,
+    userId: mockUserId,
+  };
+
+  const mockAdminContext = {
+    role: Role.ADMIN,
+    condominiumId: mockCondoId,
+    userId: 'admin-uuid',
+  };
+
+  const mockCommonArea = {
+    id: 'area-uuid-001',
+    name: 'Salão de Festas',
+    description: 'Espaço para eventos',
+    capacity: 50,
+    openTime: '08:00',
+    closeTime: '22:00',
+    operatingDays: '1,2,3,4,5,6,7',
+    requiresApproval: false,
+    icon: 'celebration',
+    isUnderMaintenance: false,
+    condominiumId: mockCondoId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockResident = {
+    id: mockResidentId,
+    userId: mockUserId,
+    unitId: null,
+    document: null,
+    phone: null,
+    canBook: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockPrisma = {
+    commonArea: {
+      findFirst: jest.fn(),
+    },
+    resident: {
+      findUnique: jest.fn(),
+    },
+    reservation: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReservationsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<ReservationsService>(ReservationsService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    jest.resetAllMocks();
+  });
+
+  describe('createReservation', () => {
+    const validInput = {
+      commonAreaId: 'area-uuid-001',
+      date: '2026-07-15',
+      startTime: '10:00',
+      endTime: '12:00',
+    };
+
+    it('(RESIDENT) deve criar reserva com dados válidos', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+      mockPrisma.reservation.create.mockResolvedValue({
+        id: 'res-uuid-001',
+        residentId: mockResidentId,
+        commonAreaId: 'area-uuid-001',
+        startTime: new Date('2026-07-15T10:00:00.000Z'),
+        endTime: new Date('2026-07-15T12:00:00.000Z'),
+        status: 'APPROVED',
+        notes: null,
+        canceledById: null,
+        canceledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createReservation(validInput, mockContext);
+
+      expect(result).toHaveProperty('id');
+      expect(result.status).toBe('APPROVED');
+      expect(mockPrisma.reservation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            residentId: mockResidentId,
+            commonAreaId: 'area-uuid-001',
+            status: 'APPROVED',
+          }),
+        }),
+      );
+    });
+
+    it('(ADMIN) deve criar reserva em nome de um residente', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+      mockPrisma.reservation.create.mockResolvedValue({
+        id: 'res-uuid-002',
+        residentId: mockResidentId,
+        commonAreaId: 'area-uuid-001',
+        startTime: new Date('2026-07-15T14:00:00.000Z'),
+        endTime: new Date('2026-07-15T16:00:00.000Z'),
+        status: 'APPROVED',
+        notes: null,
+        canceledById: null,
+        canceledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createReservation(
+        { ...validInput, residentId: mockResidentId },
+        mockAdminContext,
+      );
+
+      expect(result).toHaveProperty('id');
+      expect(result.status).toBe('APPROVED');
+    });
+
+    it('deve lançar CommonAreaNotFoundException se área não existir', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(null);
+
+      await expect(service.createReservation(validInput, mockContext))
+        .rejects.toThrow(CommonAreaNotFoundException);
+    });
+
+    it('deve lançar TenantAccessDeniedException se área for de outro condomínio', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue({
+        ...mockCommonArea,
+        condominiumId: 'outro-condo',
+      });
+
+      await expect(service.createReservation(validInput, mockContext))
+        .rejects.toThrow(TenantAccessDeniedException);
+    });
+
+    it('deve lançar erro se área estiver em manutenção', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue({
+        ...mockCommonArea,
+        isUnderMaintenance: true,
+      });
+
+      await expect(service.createReservation(validInput, mockContext))
+        .rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se data for fora dos dias operacionais', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue({
+        ...mockCommonArea,
+        operatingDays: '1,2,3,4,5',
+      });
+
+      const inputSabado = { ...validInput, date: '2026-07-18' };
+      await expect(service.createReservation(inputSabado, mockContext))
+        .rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se horário for antes da abertura', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+
+      await expect(service.createReservation(
+        { ...validInput, startTime: '06:00', endTime: '08:00' },
+        mockContext,
+      )).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se horário for depois do fechamento', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+
+      await expect(service.createReservation(
+        { ...validInput, startTime: '22:00', endTime: '23:00' },
+        mockContext,
+      )).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se startTime >= endTime', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+
+      await expect(service.createReservation(
+        { ...validInput, startTime: '14:00', endTime: '13:00' },
+        mockContext,
+      )).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se duração for menor que 2 horas', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+
+      await expect(service.createReservation(
+        { ...validInput, startTime: '14:00', endTime: '15:00' },
+        mockContext,
+      )).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve lançar erro se duração for exatamente 1h59', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+
+      await expect(service.createReservation(
+        { ...validInput, startTime: '14:00', endTime: '15:59' },
+        mockContext,
+      )).rejects.toThrow(CommonAreaValidationException);
+    });
+
+    it('deve aceitar duração de exatamente 2 horas', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+      mockPrisma.reservation.create.mockResolvedValue({
+        id: 'res-uuid-min2h',
+        residentId: mockResidentId,
+        commonAreaId: 'area-uuid-001',
+        startTime: new Date('2026-07-15T14:00:00.000Z'),
+        endTime: new Date('2026-07-15T16:00:00.000Z'),
+        status: 'APPROVED',
+        notes: null,
+        canceledById: null,
+        canceledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createReservation(
+        { ...validInput, startTime: '14:00', endTime: '16:00' },
+        mockContext,
+      );
+
+      expect(result).toHaveProperty('id');
+      expect(result.status).toBe('APPROVED');
+    });
+
+    it('deve criar reserva como PENDING quando área exigir aprovação', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue({
+        ...mockCommonArea,
+        requiresApproval: true,
+      });
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+      mockPrisma.reservation.create.mockResolvedValue({
+        id: 'res-pending',
+        residentId: mockResidentId,
+        commonAreaId: 'area-uuid-001',
+        startTime: new Date('2026-07-15T14:00:00.000Z'),
+        endTime: new Date('2026-07-15T16:00:00.000Z'),
+        status: 'PENDING',
+        notes: null,
+        canceledById: null,
+        canceledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.createReservation(validInput, mockContext);
+
+      expect(result).toHaveProperty('id');
+      expect(result.status).toBe('PENDING');
+    });
+
+    it('deve lançar erro se houver reserva conflitante', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([
+        {
+          id: 'conflict-res',
+          startTime: new Date('2026-07-15T10:00:00.000Z'),
+          endTime: new Date('2026-07-15T12:00:00.000Z'),
+          status: 'APPROVED',
+        },
+      ]);
+
+      await expect(service.createReservation(
+        { ...validInput, startTime: '11:00', endTime: '13:00' },
+        mockContext,
+      )).rejects.toThrow(ReservationConflictException);
+    });
+
+    it('deve lançar CommonAreaAccessDeniedException se RESIDENT não tiver condominiumId', async () => {
+      const contextSemCondo = { role: Role.RESIDENT, condominiumId: null, userId: 'user-id' };
+
+      await expect(service.createReservation(validInput, contextSemCondo as any))
+        .rejects.toThrow(CommonAreaAccessDeniedException);
+    });
+
+    it('deve lançar erro se RESIDENT não tiver perfil de residente', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+      mockPrisma.resident.findUnique.mockResolvedValue(null);
+
+      await expect(service.createReservation(validInput, mockContext))
+        .rejects.toThrow(ResidentNotFoundException);
+    });
+
+    it('deve lançar erro se RESIDENT não puder reservar', async () => {
+      mockPrisma.commonArea.findFirst.mockResolvedValue(mockCommonArea);
+      mockPrisma.resident.findUnique.mockResolvedValue({ ...mockResident, canBook: false });
+
+      await expect(service.createReservation(validInput, mockContext))
+        .rejects.toThrow(ResidentCannotBookException);
+    });
+  });
+
+  describe('listReservations', () => {
+    const mockReservations = [
+      {
+        id: 'res-1',
+        residentId: mockResidentId,
+        commonAreaId: 'area-1',
+        startTime: new Date('2026-07-15T10:00:00.000Z'),
+        endTime: new Date('2026-07-15T12:00:00.000Z'),
+        status: 'APPROVED',
+        notes: null,
+        canceledById: null,
+        canceledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        commonArea: { id: 'area-1', name: 'Salão de Festas', icon: 'celebration' },
+      },
+    ];
+
+    it('(RESIDENT) deve listar próprias reservas', async () => {
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue(mockReservations);
+      mockPrisma.reservation.count.mockResolvedValue(1);
+
+      const result = await service.listReservations(mockContext);
+
+      expect(result.reservations).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(mockPrisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ residentId: mockResidentId }),
+        }),
+      );
+    });
+
+    it('(ADMIN) deve listar reservas do condomínio', async () => {
+      mockPrisma.reservation.findMany.mockResolvedValue(mockReservations);
+      mockPrisma.reservation.count.mockResolvedValue(1);
+
+      const result = await service.listReservations(mockAdminContext);
+
+      expect(result.reservations).toHaveLength(1);
+      expect(mockPrisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            commonArea: { condominiumId: mockCondoId },
+          }),
+        }),
+      );
+    });
+
+    it('deve filtrar por status', async () => {
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+      mockPrisma.reservation.count.mockResolvedValue(0);
+
+      await service.listReservations(mockContext, { status: 'PENDING' });
+
+      expect(mockPrisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'PENDING' }),
+        }),
+      );
+    });
+
+    it('deve retornar lista vazia se não houver reservas', async () => {
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.findMany.mockResolvedValue([]);
+      mockPrisma.reservation.count.mockResolvedValue(0);
+
+      const result = await service.listReservations(mockContext);
+
+      expect(result.reservations).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('deve lançar erro se RESIDENT não tiver perfil', async () => {
+      mockPrisma.resident.findUnique.mockResolvedValue(null);
+
+      await expect(service.listReservations(mockContext))
+        .rejects.toThrow(ResidentNotFoundException);
+    });
+
+    it('deve lançar CommonAreaAccessDeniedException se não tiver condominiumId', async () => {
+      const ctx = { role: Role.RESIDENT, condominiumId: null, userId: 'user' };
+
+      await expect(service.listReservations(ctx as any))
+        .rejects.toThrow(CommonAreaAccessDeniedException);
+    });
+  });
+
+  describe('cancelReservation', () => {
+    const mockReservation = {
+      id: 'res-1',
+      residentId: mockResidentId,
+      commonAreaId: 'area-1',
+      startTime: new Date('2026-07-20T14:00:00.000Z'),
+      endTime: new Date('2026-07-20T16:00:00.000Z'),
+      status: 'APPROVED',
+      notes: null,
+      canceledById: null,
+      canceledAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      commonArea: { id: 'area-1', condominiumId: mockCondoId },
+    };
+
+    it('(RESIDENT) deve cancelar própria reserva', async () => {
+      mockPrisma.reservation.findFirst.mockResolvedValue(mockReservation);
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+      mockPrisma.reservation.update.mockResolvedValue({ ...mockReservation, status: 'CANCELED', canceledById: mockUserId, canceledAt: new Date() });
+
+      const result = await service.cancelReservation('res-1', mockContext);
+
+      expect(result.status).toBe('CANCELED');
+      expect(mockPrisma.reservation.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'res-1' },
+          data: expect.objectContaining({
+            status: 'CANCELED',
+            canceledById: mockUserId,
+          }),
+        }),
+      );
+    });
+
+    it('(ADMIN) deve cancelar qualquer reserva do condomínio', async () => {
+      mockPrisma.reservation.findFirst.mockResolvedValue(mockReservation);
+      mockPrisma.reservation.update.mockResolvedValue({ ...mockReservation, status: 'CANCELED', canceledById: 'admin-uuid', canceledAt: new Date() });
+
+      const result = await service.cancelReservation('res-1', mockAdminContext);
+
+      expect(result.status).toBe('CANCELED');
+    });
+
+    it('deve lançar ReservationNotFoundException se reserva não existir', async () => {
+      mockPrisma.reservation.findFirst.mockResolvedValue(null);
+
+      await expect(service.cancelReservation('inexistente', mockContext))
+        .rejects.toThrow(ReservationNotFoundException);
+    });
+
+    it('deve lançar TenantAccessDeniedException se reserva for de outro condomínio', async () => {
+      mockPrisma.reservation.findFirst.mockResolvedValue({
+        ...mockReservation,
+        commonArea: { id: 'area-1', condominiumId: 'outro-condo' },
+      });
+
+      await expect(service.cancelReservation('res-1', mockContext))
+        .rejects.toThrow(TenantAccessDeniedException);
+    });
+
+    it('deve lançar ReservationAlreadyCanceledException se já cancelada', async () => {
+      mockPrisma.reservation.findFirst.mockResolvedValue({
+        ...mockReservation,
+        status: 'CANCELED',
+      });
+
+      await expect(service.cancelReservation('res-1', mockContext))
+        .rejects.toThrow(ReservationAlreadyCanceledException);
+    });
+
+    it('(RESIDENT) deve lançar erro ao cancelar reserva de outro', async () => {
+      mockPrisma.reservation.findFirst.mockResolvedValue({
+        ...mockReservation,
+        residentId: 'outro-resident',
+      });
+      mockPrisma.resident.findUnique.mockResolvedValue(mockResident);
+
+      await expect(service.cancelReservation('res-1', mockContext))
+        .rejects.toThrow(ReservationAccessDeniedException);
+    });
+  });
+});

--- a/apps/api/src/reservations/reservations.service.ts
+++ b/apps/api/src/reservations/reservations.service.ts
@@ -1,0 +1,286 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Role } from '@prisma/client';
+import {
+  CommonAreaNotFoundException,
+  CommonAreaAccessDeniedException,
+  TenantAccessDeniedException,
+  CommonAreaValidationException,
+} from '../common-areas/exceptions';
+import {
+  ReservationConflictException,
+  ResidentNotFoundException,
+  ResidentCannotBookException,
+  ReservationNotFoundException,
+  ReservationAlreadyCanceledException,
+  ReservationAccessDeniedException,
+} from './exceptions';
+import {
+  CreateReservationInput,
+  ReservationOutput,
+  ReservationListOutput,
+  ListReservationsQuery,
+} from './interfaces/reservation.interface';
+
+interface ServiceContext {
+  role: string;
+  condominiumId: string | null;
+  userId: string;
+}
+
+@Injectable()
+export class ReservationsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createReservation(
+    input: CreateReservationInput,
+    context: ServiceContext,
+  ): Promise<ReservationOutput> {
+    if (!context.condominiumId) {
+      throw new CommonAreaAccessDeniedException('reservar');
+    }
+
+    const commonArea = await this.prisma.commonArea.findFirst({
+      where: { id: input.commonAreaId },
+    });
+
+    if (!commonArea) {
+      throw new CommonAreaNotFoundException(input.commonAreaId);
+    }
+
+    if (commonArea.condominiumId !== context.condominiumId) {
+      throw new TenantAccessDeniedException();
+    }
+
+    if (commonArea.isUnderMaintenance) {
+      throw new CommonAreaValidationException([
+        'Esta área está em manutenção.',
+      ]);
+    }
+
+    const requestedDate = new Date(input.date + 'T12:00:00Z');
+    const dayOfWeek = ((requestedDate.getUTCDay() + 6) % 7) + 1;
+
+    const operatingDays: number[] = typeof commonArea.operatingDays === 'string'
+      ? commonArea.operatingDays.split(',').map(Number)
+      : Array.isArray(commonArea.operatingDays)
+        ? commonArea.operatingDays.map(Number)
+        : [];
+
+    if (!operatingDays.includes(dayOfWeek)) {
+      throw new CommonAreaValidationException([
+        'Esta área não funciona no dia solicitado.',
+      ]);
+    }
+
+    const { startTime, endTime } = input;
+
+    if (startTime < commonArea.openTime) {
+      throw new CommonAreaValidationException([
+        `O horário de início (${startTime}) é antes da abertura (${commonArea.openTime}).`,
+      ]);
+    }
+
+    if (endTime > commonArea.closeTime) {
+      throw new CommonAreaValidationException([
+        `O horário de fim (${endTime}) é depois do fechamento (${commonArea.closeTime}).`,
+      ]);
+    }
+
+    if (startTime >= endTime) {
+      throw new CommonAreaValidationException([
+        'O horário de início deve ser anterior ao horário de fim.',
+      ]);
+    }
+
+    const [startH, startM] = startTime.split(':').map(Number);
+    const [endH, endM] = endTime.split(':').map(Number);
+    const durationMinutes = (endH * 60 + endM) - (startH * 60 + startM);
+
+    if (durationMinutes < 120) {
+      throw new CommonAreaValidationException([
+        'A reserva deve ter no mínimo 2 horas de duração.',
+      ]);
+    }
+
+    let residentId = input.residentId;
+
+    if (context.role === Role.RESIDENT) {
+      const resident = await this.prisma.resident.findUnique({
+        where: { userId: context.userId },
+      });
+
+      if (!resident) {
+        throw new ResidentNotFoundException();
+      }
+
+      if (!resident.canBook) {
+        throw new ResidentCannotBookException();
+      }
+
+      residentId = resident.id;
+    }
+
+    if (!residentId) {
+      throw new CommonAreaValidationException([
+        'Morador não identificado para a reserva.',
+      ]);
+    }
+
+    const startDateTime = new Date(`${input.date}T${startTime}:00.000Z`);
+    const endDateTime = new Date(`${input.date}T${endTime}:00.000Z`);
+
+    const conflicts = await this.prisma.reservation.findMany({
+      where: {
+        commonAreaId: input.commonAreaId,
+        status: { in: ['PENDING', 'APPROVED'] },
+        startTime: { lt: endDateTime },
+        endTime: { gt: startDateTime },
+      },
+      take: 1,
+    });
+
+    if (conflicts.length > 0) {
+      throw new ReservationConflictException();
+    }
+
+    const status = commonArea.requiresApproval ? 'PENDING' : 'APPROVED';
+
+    const reservation = await this.prisma.reservation.create({
+      data: {
+        residentId,
+        commonAreaId: input.commonAreaId,
+        startTime: startDateTime,
+        endTime: endDateTime,
+        status,
+        notes: input.notes,
+      },
+    });
+
+    return reservation as ReservationOutput;
+  }
+
+  async listReservations(
+    context: ServiceContext,
+    query?: ListReservationsQuery,
+  ): Promise<ReservationListOutput> {
+    if (!context.condominiumId) {
+      throw new CommonAreaAccessDeniedException('listar');
+    }
+
+    let residentId: string | undefined;
+
+    if (context.role === Role.RESIDENT) {
+      const resident = await this.prisma.resident.findUnique({
+        where: { userId: context.userId },
+      });
+
+      if (!resident) {
+        throw new ResidentNotFoundException();
+      }
+
+      residentId = resident.id;
+    }
+
+    const page = query?.page ?? 1;
+    const limit = query?.limit ?? 10;
+    const skip = (page - 1) * limit;
+
+    const where: Record<string, unknown> = {};
+
+    if (residentId) {
+      where.residentId = residentId;
+    } else {
+      where.commonArea = { condominiumId: context.condominiumId };
+    }
+
+    if (query?.status) {
+      const statuses = query.status.split(',').map((s) => s.trim()).filter(Boolean);
+      if (statuses.length === 1) {
+        where.status = statuses[0];
+      } else if (statuses.length > 1) {
+        where.status = { in: statuses };
+      }
+    }
+
+    if (query?.from) {
+      where.endTime = { gte: new Date(query.from + 'T00:00:00.000Z') };
+    }
+
+    if (query?.to) {
+      where.startTime = { lte: new Date(query.to + 'T23:59:59.999Z') };
+    }
+
+    const [reservations, total] = await Promise.all([
+      this.prisma.reservation.findMany({
+        where,
+        include: {
+          commonArea: { select: { id: true, name: true, icon: true, capacity: true } },
+          resident: {
+            select: {
+              id: true,
+              user: { select: { name: true, email: true } },
+            },
+          },
+        },
+        orderBy: { startTime: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.reservation.count({ where }),
+    ]);
+
+    return {
+      reservations: reservations as unknown as ReservationOutput[],
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async cancelReservation(
+    reservationId: string,
+    context: ServiceContext,
+  ): Promise<ReservationOutput> {
+    const reservation = await this.prisma.reservation.findFirst({
+      where: { id: reservationId },
+      include: {
+        commonArea: { select: { condominiumId: true } },
+      },
+    });
+
+    if (!reservation) {
+      throw new ReservationNotFoundException(reservationId);
+    }
+
+    if (reservation.commonArea.condominiumId !== context.condominiumId) {
+      throw new TenantAccessDeniedException();
+    }
+
+    if (reservation.status === 'CANCELED') {
+      throw new ReservationAlreadyCanceledException();
+    }
+
+    if (context.role === Role.RESIDENT) {
+      const resident = await this.prisma.resident.findUnique({
+        where: { userId: context.userId },
+      });
+
+      if (!resident || resident.id !== reservation.residentId) {
+        throw new ReservationAccessDeniedException();
+      }
+    }
+
+    const updated = await this.prisma.reservation.update({
+      where: { id: reservationId },
+      data: {
+        status: 'CANCELED',
+        canceledById: context.userId,
+        canceledAt: new Date(),
+      },
+    });
+
+    return updated as ReservationOutput;
+  }
+}

--- a/apps/api/swagger.json
+++ b/apps/api/swagger.json
@@ -608,11 +608,159 @@
           "common-areas"
         ]
       }
+    },
+    "/api/v1/reservations": {
+      "get": {
+        "description": "\n      **[US09/US10]** Lista reservas.\n\n      **Acesso:**\n      - RESIDENT: lista apenas as próprias reservas\n      - ADMIN: lista todas as reservas do condomínio\n    ",
+        "operationId": "ReservationsController_findAll",
+        "parameters": [
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "page",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "status",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de reservas."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "US09/US10 - Listar reservas",
+        "tags": [
+          "reservations"
+        ]
+      },
+      "post": {
+        "description": "\n      **[US07]** Realiza uma reserva de área comum em um período disponível.\n      \n      **Acesso:** Moradores (RESIDENT) e Administradores (ADMIN)\n      **Regras de negócio:** RN01, RN03, RN03.1\n      \n      Para RESIDENT, o residentId é obtido automaticamente do token JWT.\n      Para ADMIN, pode-se informar o residentId no body.\n    ",
+        "operationId": "ReservationsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateReservationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Reserva criada com sucesso."
+          },
+          "400": {
+            "description": "Dados de entrada inválidos."
+          },
+          "401": {
+            "description": "Não autenticado."
+          },
+          "403": {
+            "description": "Acesso negado."
+          },
+          "404": {
+            "description": "Área ou morador não encontrado."
+          },
+          "409": {
+            "description": "Conflito de horário."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "US07 - Criar uma reserva",
+        "tags": [
+          "reservations"
+        ]
+      }
+    },
+    "/api/v1/reservations/{id}/cancel": {
+      "patch": {
+        "description": "\n      **[US08]** Cancela uma reserva.\n      \n      **Acesso:**\n      - RESIDENT: cancela apenas as próprias reservas\n      - ADMIN: cancela qualquer reserva do condomínio\n      \n      Registra o ID do usuário que cancelou e a data do cancelamento (auditoria).\n    ",
+        "operationId": "ReservationsController_cancel",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reserva cancelada com sucesso."
+          },
+          "401": {
+            "description": "Não autenticado."
+          },
+          "403": {
+            "description": "Acesso negado."
+          },
+          "404": {
+            "description": "Reserva não encontrada."
+          },
+          "409": {
+            "description": "Reserva já cancelada."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "US08 - Cancelar reserva",
+        "tags": [
+          "reservations"
+        ]
+      }
     }
   },
   "info": {
     "title": "🚀 Reserva Aí! - API de Gestão de Condomínios",
-    "description": "## 📝 Sobre o Projeto\nO **Reserva Aí!** é uma solução completa para a modernização da gestão de condomínios.\n\n### 🛠️ Guia de Uso\n1. **Autenticação:** Após login, use o token JWT no header Authorization: `Bearer <token>`\n2. **Isolamento (Multi-tenant):** Dados isolados por condomínio (RN01)\n3. **Roles:** ADMIN (administrador), RESIDENT (morador), SUPER_ADMIN\n\n### 🔐 Segurança e Permissões\n| Role | Acesso |\n|------|--------|\n| ADMIN | CRUD completo: condomínio, moradores e áreas |\n| RESIDENT | READ: áreas comuns; BOOK: reservas |\n| SUPER_ADMIN | Global (sem condomínio vinculado) |\n\n### 📋 User Stories Implementadas\n| US | Descrição |\n|----|----------|\n| US01 | Criar conta e registrar condomínio |\n| US02 | Login e gerenciar dados do condomínio |\n| US03 | Cadastrar moradores (Admin) |\n| US03.1 | Login de morador |\n| US04 | Cadastrar e gerenciar áreas comuns (Admin) |\n| US05 | Visualizar áreas comuns |\n| US06 | Consultar disponibilidade de áreas comuns |\n\n*Desenvolvido em NestJS + Prisma ORM + PostgreSQL (Neon.tech)*",
+    "description": "## 📝 Sobre o Projeto\nO **Reserva Aí!** é uma solução completa para a modernização da gestão de condomínios.\n\n### 🛠️ Guia de Uso\n1. **Autenticação:** Após login, use o token JWT no header Authorization: `Bearer <token>`\n2. **Isolamento (Multi-tenant):** Dados isolados por condomínio (RN01)\n3. **Roles:** ADMIN (administrador), RESIDENT (morador), SUPER_ADMIN\n\n### 🔐 Segurança e Permissões\n| Role | Acesso |\n|------|--------|\n| ADMIN | CRUD completo: condomínio, moradores e áreas |\n| RESIDENT | READ: áreas comuns; BOOK: reservas |\n| SUPER_ADMIN | Global (sem condomínio vinculado) |\n\n### 📋 User Stories Implementadas\n| US | Descrição |\n|----|----------|\n| US01 | Criar conta e registrar condomínio |\n| US02 | Login e gerenciar dados do condomínio |\n| US03 | Cadastrar moradores (Admin) |\n| US03.1 | Login de morador |\n| US04 | Cadastrar e gerenciar áreas comuns (Admin) |\n| US05 | Visualizar áreas comuns |\n| US06 | Consultar disponibilidade de áreas comuns |\n| US07 | Realizar reserva de área comum |\n\n*Desenvolvido em NestJS + Prisma ORM + PostgreSQL (Neon.tech)*",
     "version": "1.0",
     "contact": {}
   },
@@ -624,6 +772,10 @@
     {
       "name": "residents",
       "description": "US03 - Gestão de Moradores (Admin only)"
+    },
+    {
+      "name": "reservations",
+      "description": "US07 - Reservas"
     },
     {
       "name": "common-areas",
@@ -863,6 +1015,44 @@
             "description": "Indica se a área está em manutenção"
           }
         }
+      },
+      "CreateReservationDto": {
+        "type": "object",
+        "properties": {
+          "commonAreaId": {
+            "type": "string",
+            "description": "UUID da área comum"
+          },
+          "date": {
+            "type": "string",
+            "description": "Data da reserva (YYYY-MM-DD)",
+            "example": "2026-07-15"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "Horário de início (HH:MM)",
+            "example": "10:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "Horário de fim (HH:MM)",
+            "example": "12:00"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Observações"
+          },
+          "residentId": {
+            "type": "string",
+            "description": "UUID do morador (apenas admin)"
+          }
+        },
+        "required": [
+          "commonAreaId",
+          "date",
+          "startTime",
+          "endTime"
+        ]
       }
     }
   }

--- a/apps/web/src/modules/admin/pages/ReservationsPage.vue
+++ b/apps/web/src/modules/admin/pages/ReservationsPage.vue
@@ -1,44 +1,164 @@
 <template>
   <div class="flex min-h-screen bg-surface text-on-surface">
-    <!-- SideNavBar -->
-    <SideNavBar 
-      role="ADMIN" 
+    <SideNavBar
+      role="ADMIN"
       :userName="userName"
       :collapsed="sidebarCollapsed"
       @toggle-collapse="toggleCollapse"
       @logout="handleLogout"
-      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" 
+      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']"
     />
 
-    <!-- Main Content Area -->
     <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
-      <TopAppBar 
-        :userName="userName" 
+      <TopAppBar
+        :userName="userName"
         userRole="ADMIN"
-        @toggle-sidebar="sidebarOpen = !sidebarOpen" 
+        @toggle-sidebar="sidebarOpen = !sidebarOpen"
       />
 
-      <div class="flex-1 p-4 md:p-6 lg:p-8 flex flex-col items-center justify-center text-center">
-        <div class="w-20 h-20 bg-sky-100 rounded-full flex items-center justify-center mb-6">
-          <span class="material-symbols-outlined text-4xl text-sky-500">construction</span>
+      <div class="flex-1 p-4 md:p-6 lg:p-8">
+        <div class="mb-6 md:mb-8">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
+              <span class="material-symbols-outlined text-primary">event_available</span>
+            </div>
+            <h1 class="text-2xl font-bold text-cyan-900">Reservas</h1>
+          </div>
+          <p class="text-slate-500 ml-[52px]">Todas as reservas do condomínio</p>
         </div>
-        <h1 class="text-2xl font-bold text-cyan-900 mb-2">Reservas</h1>
-        <p class="text-slate-500 max-w-md mb-2">Esta funcionalidade está em desenvolvimento.</p>
-        <span class="inline-flex items-center gap-1 px-3 py-1 bg-sky-50 text-sky-700 rounded-full text-sm font-medium">US10 - Todas as reservas do condomínio</span>
+
+        <div v-if="loading" class="flex items-center justify-center py-12">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </div>
+
+        <template v-else>
+          <!-- Filters -->
+          <div class="flex flex-wrap items-center gap-3 mb-6">
+            <button
+              v-for="f in filterOptions"
+              :key="f.value"
+              @click="statusFilter = f.value; fetchReservations()"
+              :class="['px-4 py-2 rounded-xl text-sm font-medium transition-all', statusFilter === f.value ? 'bg-primary text-white shadow-sm' : 'bg-white text-slate-600 border border-slate-200 hover:bg-slate-50']"
+            >
+              {{ f.label }}
+            </button>
+          </div>
+
+          <!-- Empty -->
+          <div v-if="reservations.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
+            <div class="w-20 h-20 bg-sky-100 rounded-full flex items-center justify-center mb-6">
+              <span class="material-symbols-outlined text-4xl text-sky-500">event_busy</span>
+            </div>
+            <h2 class="text-xl font-bold text-cyan-900 mb-2">Nenhuma reserva encontrada</h2>
+            <p class="text-slate-500 max-w-md">{{ statusFilter ? 'Nenhuma reserva com este status.' : 'Nenhuma reserva cadastrada no condomínio.' }}</p>
+          </div>
+
+          <!-- Table -->
+          <div v-else class="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden">
+            <div class="overflow-x-auto">
+              <table class="w-full">
+                <thead>
+                  <tr class="border-b border-slate-100 bg-slate-50/50">
+                    <th class="text-left text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 md:px-5 py-3">Área</th>
+                    <th class="text-left text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 py-3">Morador</th>
+                    <th class="text-left text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 py-3">Data</th>
+                    <th class="text-left text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 py-3">Horário</th>
+                    <th class="text-left text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 py-3">Status</th>
+                    <th class="text-right text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 md:px-5 py-3">Ações</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="res in reservations"
+                    :key="res.id"
+                    @click="toggleExpand(res.id)"
+                    class="border-b border-slate-50 hover:bg-slate-50/50 transition-colors cursor-pointer"
+                  >
+                    <td class="px-4 md:px-5 py-4">
+                      <div class="flex items-center gap-3">
+                        <div class="w-9 h-9 bg-primary/10 rounded-lg flex items-center justify-center shrink-0">
+                          <span class="material-symbols-outlined text-primary text-[18px]">{{ res.commonArea?.icon || 'home_work' }}</span>
+                        </div>
+                        <span class="font-medium text-cyan-900 text-sm">{{ res.commonArea?.name }}</span>
+                      </div>
+                    </td>
+                    <td class="px-4 py-4 text-sm text-slate-600">{{ res.resident?.user?.name || 'N/D' }}</td>
+                    <td class="px-4 py-4 text-sm text-slate-600 whitespace-nowrap">{{ formatResDate(res.startTime) }}</td>
+                    <td class="px-4 py-4 text-sm text-slate-600 whitespace-nowrap">{{ formatTime(res.startTime) }} - {{ formatTime(res.endTime) }}</td>
+                    <td class="px-4 py-4">
+                      <span :class="['px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wider', statusClass(res.status)]">{{ statusLabel(res.status) }}</span>
+                    </td>
+                    <td class="px-4 md:px-5 py-4 text-right">
+                      <span class="material-symbols-outlined text-slate-400 transition-transform" :class="expandedId === res.id ? 'rotate-180' : ''">expand_more</span>
+                    </td>
+                  </tr>
+
+                  <!-- Expanded Row -->
+                  <tr v-for="res in expandedReservations" :key="'exp-' + res.id">
+                    <td colspan="6" class="px-4 md:px-5 pb-4">
+                      <div class="bg-slate-50 rounded-xl p-4">
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                          <div class="space-y-1.5 text-sm">
+                            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Detalhes</p>
+                            <p class="text-slate-600"><strong>Área:</strong> {{ res.commonArea?.name }}</p>
+                            <p class="text-slate-600"><strong>Morador:</strong> {{ res.resident?.user?.name || 'N/D' }}</p>
+                            <p v-if="res.resident?.user?.email" class="text-slate-600"><strong>Email:</strong> {{ res.resident.user.email }}</p>
+                            <p v-if="res.notes" class="text-slate-600"><strong>Obs:</strong> {{ res.notes }}</p>
+                            <p v-if="res.canceledAt" class="text-red-500"><strong>Cancelado em:</strong> {{ formatResDate(res.canceledAt) }}</p>
+                          </div>
+                          <div class="space-y-1.5 text-sm">
+                            <p class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Disponibilidade do dia</p>
+                            <div v-if="timelineLoading === res.id" class="flex items-center py-2">
+                              <div class="animate-spin h-4 w-4 border-2 border-primary border-t-transparent rounded-full"></div>
+                            </div>
+                            <div v-else-if="timelines[res.id]" class="space-y-1">
+                              <div v-for="(slot, idx) in timelines[res.id]" :key="idx" class="flex items-center gap-2 text-sm" :class="slot.available ? 'text-emerald-700' : 'text-red-700'">
+                                <span class="material-symbols-outlined text-[14px]">{{ slot.available ? 'check_circle' : 'block' }}</span>
+                                <span>{{ slot.start }} - {{ slot.end }}</span>
+                                <span v-if="!slot.available" class="text-xs text-red-400">({{ statusLabel(slot.status) }})</span>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="flex flex-col gap-2 justify-start items-end">
+                            <button
+                              v-if="res.status === 'PENDING' || res.status === 'APPROVED'"
+                              @click.stop="confirmCancel(res)"
+                              class="inline-flex items-center gap-1.5 px-4 py-2 bg-red-50 text-red-700 border border-red-200 rounded-xl hover:bg-red-100 transition-all text-sm font-medium"
+                            >
+                              <span class="material-symbols-outlined text-[16px]">cancel</span>
+                              Cancelar
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Pagination -->
+            <div v-if="totalPages > 1" class="flex items-center justify-center gap-2 py-4 border-t border-slate-100">
+              <button
+                v-for="p in totalPages"
+                :key="p"
+                @click="goToPage(p)"
+                :class="['min-w-[36px] h-9 rounded-lg text-sm font-medium transition-all', p === page ? 'bg-primary text-white shadow-sm' : 'text-slate-600 hover:bg-slate-100']"
+              >
+                {{ p }}
+              </button>
+            </div>
+          </div>
+        </template>
       </div>
     </main>
 
-    <!-- Mobile Overlay -->
-    <div 
-      v-if="sidebarOpen" 
-      class="fixed inset-0 bg-black/50 z-40 md:hidden"
-      @click="sidebarOpen = false"
-    ></div>
+    <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
 import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
@@ -46,18 +166,185 @@ import { authService } from '@/modules/auth/services/auth.service'
 import { http } from '@/api/http'
 import { useSidebar } from '@/modules/shared/composables/useSidebar'
 
+interface CommonAreaInfo {
+  id: string
+  name: string
+  icon: string | null
+  capacity: number | null
+}
+
+interface ResidentInfo {
+  id: string
+  user: { name: string; email: string }
+}
+
+interface Reservation {
+  id: string
+  residentId: string
+  commonAreaId: string
+  startTime: string
+  endTime: string
+  status: string
+  notes: string | null
+  canceledById: string | null
+  canceledAt: string | null
+  createdAt: string
+  updatedAt: string
+  commonArea: CommonAreaInfo | null
+  resident: ResidentInfo | null
+}
+
+interface ListResponse {
+  reservations: Reservation[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+interface TimeSlot {
+  start: string
+  end: string
+  available: boolean
+  status?: string
+}
+
 const router = useRouter()
 const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
 
 const user = authService.getUser()
 const userName = ref(user?.name || '')
 
-const handleLogout = async () => {
+const reservations = ref<Reservation[]>([])
+const loading = ref(true)
+const page = ref(1)
+const totalPages = ref(1)
+const statusFilter = ref('')
+const expandedId = ref<string | null>(null)
+const timelines = ref<Record<string, TimeSlot[]>>({})
+const timelineLoading = ref<string | null>(null)
+
+const filterOptions = [
+  { label: 'Todas', value: '' },
+  { label: 'Pendentes', value: 'PENDING' },
+  { label: 'Confirmadas', value: 'APPROVED' },
+  { label: 'Canceladas', value: 'CANCELED' },
+]
+
+const expandedReservations = computed(() => {
+  return reservations.value.filter((r) => expandedId.value === r.id)
+})
+
+function statusClass(status: string): string {
+  const map: Record<string, string> = {
+    PENDING: 'bg-amber-50 text-amber-700',
+    APPROVED: 'bg-emerald-50 text-emerald-700',
+    REJECTED: 'bg-red-50 text-red-700',
+    CANCELED: 'bg-slate-100 text-slate-500',
+  }
+  return map[status] || 'bg-slate-100 text-slate-500'
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    PENDING: 'Pendente',
+    APPROVED: 'Confirmada',
+    REJECTED: 'Rejeitada',
+    CANCELED: 'Cancelada',
+  }
+  return map[status] || status
+}
+
+function formatResDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+}
+
+async function fetchReservations() {
+  loading.value = true
   try {
-    await http.post('/auth/logout')
-  } catch { /* ignora */ }
+    const params: Record<string, any> = { page: page.value, limit: 10 }
+    if (statusFilter.value) params.status = statusFilter.value
+    const res = await http.get('/reservations', { params })
+    const data = (res.data as any).data as ListResponse
+    reservations.value = data.reservations
+    totalPages.value = data.totalPages
+  } catch {
+    reservations.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function fetchTimeline(reservation: Reservation) {
+  timelineLoading.value = reservation.id
+  try {
+    const dateStr = reservation.startTime.split('T')[0]
+    const res = await http.get(`/common-areas/${reservation.commonAreaId}/availability`, {
+      params: { date: dateStr },
+    })
+    const availability = (res.data as any).data as any
+    const slots: TimeSlot[] = []
+    let cursor = availability.openTime
+    const sorted = [...(availability.conflicts || [])].sort((a: any, b: any) => a.startTime.localeCompare(b.startTime))
+    for (const c of sorted) {
+      if (cursor < c.startTime) slots.push({ start: cursor, end: c.startTime, available: true })
+      slots.push({ start: c.startTime, end: c.endTime, available: false, status: c.status })
+      cursor = c.endTime > cursor ? c.endTime : cursor
+    }
+    if (cursor < availability.closeTime) slots.push({ start: cursor, end: availability.closeTime, available: true })
+    timelines.value[reservation.id] = slots
+  } catch {
+    timelines.value[reservation.id] = []
+  } finally {
+    timelineLoading.value = null
+  }
+}
+
+function toggleExpand(id: string) {
+  if (expandedId.value === id) {
+    expandedId.value = null
+    return
+  }
+  expandedId.value = id
+  const res = reservations.value.find((r) => r.id === id)
+  if (res && !timelines.value[id]) fetchTimeline(res)
+}
+
+async function confirmCancel(res: Reservation) {
+  if (!confirm(`Cancelar reserva de ${res.resident?.user?.name || 'N/D'} em "${res.commonArea?.name}"?`)) return
+  try {
+    await http.patch(`/reservations/${res.id}/cancel`)
+    timelines.value = {}
+    await fetchReservations()
+    expandedId.value = null
+  } catch {
+    alert('Erro ao cancelar reserva.')
+  }
+}
+
+function goToPage(p: number) {
+  page.value = p
+  fetchReservations()
+}
+
+const handleLogout = async () => {
+  try { await http.post('/auth/logout') } catch {}
   authService.logout()
   router.push('/')
 }
 
+onMounted(() => {
+  fetchReservations()
+})
 </script>
+
+<style scoped>
+.material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+</style>

--- a/apps/web/src/modules/resident/pages/AvailabilityPage.vue
+++ b/apps/web/src/modules/resident/pages/AvailabilityPage.vue
@@ -63,6 +63,21 @@
             </div>
           </div>
 
+          <!-- CTA Card -->
+          <div v-if="selectedAreaId" class="bg-gradient-to-r from-primary/5 to-white border border-primary/10 rounded-2xl p-4 mb-6 flex items-center justify-between">
+            <div>
+              <p class="text-sm font-semibold text-cyan-900">Quer fazer uma reserva?</p>
+              <p class="text-xs text-slate-500">Clique em <span class="text-primary font-medium">Reservar</span> ao lado de um horário disponível</p>
+            </div>
+            <router-link
+              :to="{ name: 'resident-reservations-new', query: { areaId: selectedAreaId } }"
+              class="inline-flex items-center gap-1.5 px-4 py-2 bg-primary text-white rounded-xl hover:brightness-90 transition-all text-sm font-semibold"
+            >
+              <span class="material-symbols-outlined text-[16px]">add_circle</span>
+              Nova Reserva
+            </router-link>
+          </div>
+
           <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
             <!-- Calendar -->
             <div class="xl:col-span-2 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
@@ -180,6 +195,13 @@
                     <span v-if="!slot.available" class="text-xs text-red-400 ml-auto">
                       {{ statusLabel(slot.status) }}
                     </span>
+                    <button
+                      v-if="slot.available"
+                      @click.stop="goToReservation(slot)"
+                      class="ml-auto text-xs font-semibold text-primary hover:text-primary/80 transition-colors"
+                    >
+                      Reservar
+                    </button>
                   </div>
                 </div>
               </template>
@@ -289,6 +311,14 @@ const operatingDaysSet = computed(() => {
   return new Set(days.map((d) => map[d] ?? d))
 })
 
+function isTimePast(time: string, date: string): boolean {
+  const today = new Date()
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+  if (date !== todayStr) return false
+  const [h, m] = time.split(':').map(Number)
+  return h * 60 + m <= today.getHours() * 60 + today.getMinutes()
+}
+
 const timeSlots = computed<TimeSlot[]>(() => {
   if (!result.value) return []
   const { openTime, closeTime, conflicts } = result.value
@@ -300,14 +330,16 @@ const timeSlots = computed<TimeSlot[]>(() => {
 
   for (const c of sorted) {
     if (cursor < c.startTime) {
-      slots.push({ start: cursor, end: c.startTime, available: true })
+      const past = isTimePast(cursor, selectedDate.value)
+      slots.push({ start: cursor, end: c.startTime, available: !past })
     }
     slots.push({ start: c.startTime, end: c.endTime, available: false, status: c.status })
     cursor = c.endTime > cursor ? c.endTime : cursor
   }
 
   if (cursor < closeTime) {
-    slots.push({ start: cursor, end: closeTime, available: true })
+    const past = isTimePast(cursor, selectedDate.value)
+    slots.push({ start: cursor, end: closeTime, available: !past })
   }
 
   return slots
@@ -449,7 +481,21 @@ async function fetchAreas() {
   }
 }
 
-const handleQuickAction = () => {}
+function goToReservation(slot: TimeSlot) {
+  router.push({
+    name: 'resident-reservations-new',
+    query: {
+      areaId: selectedAreaId.value,
+      date: selectedDate.value,
+      startTime: slot.start,
+      endTime: slot.end,
+    },
+  })
+}
+
+const handleQuickAction = (actionId: string) => {
+  if (actionId === 'new-reservation') router.push('/resident/reservations/new')
+}
 
 const handleLogout = async () => {
   try { await http.post('/auth/logout') } catch {}

--- a/apps/web/src/modules/resident/pages/MyReservationsPage.vue
+++ b/apps/web/src/modules/resident/pages/MyReservationsPage.vue
@@ -1,44 +1,196 @@
 <template>
   <div class="flex min-h-screen bg-surface text-on-surface">
-    <!-- SideNavBar -->
-    <SideNavBar 
-      role="RESIDENT" 
+    <SideNavBar
+      role="RESIDENT"
       :userName="userName"
       :collapsed="sidebarCollapsed"
       @toggle-collapse="toggleCollapse"
+      @cta-click="handleQuickAction"
       @logout="handleLogout"
-      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" 
+      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']"
     />
 
-    <!-- Main Content Area -->
     <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
-      <TopAppBar 
-        :userName="userName" 
+      <TopAppBar
+        :userName="userName"
         userRole="RESIDENT"
-        @toggle-sidebar="sidebarOpen = !sidebarOpen" 
+        @toggle-sidebar="sidebarOpen = !sidebarOpen"
       />
 
-      <div class="flex-1 p-4 md:p-6 lg:p-8 flex flex-col items-center justify-center text-center">
-        <div class="w-20 h-20 bg-sky-100 rounded-full flex items-center justify-center mb-6">
-          <span class="material-symbols-outlined text-4xl text-sky-500">construction</span>
+      <div class="flex-1 p-4 md:p-6 lg:p-8">
+        <div class="mb-6 md:mb-8">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
+              <span class="material-symbols-outlined text-primary">event_available</span>
+            </div>
+            <h1 class="text-2xl font-bold text-cyan-900">Minhas Reservas</h1>
+            <router-link
+              to="/resident/reservations/new"
+              class="ml-auto inline-flex items-center gap-1.5 px-4 py-2 bg-primary text-white rounded-xl hover:brightness-90 transition-all text-sm font-semibold"
+            >
+              <span class="material-symbols-outlined text-[16px]">add_circle</span>
+              Nova Reserva
+            </router-link>
+          </div>
+          <p class="text-slate-500 ml-[52px]">Gerencie suas reservas nas áreas comuns</p>
         </div>
-        <h1 class="text-2xl font-bold text-cyan-900 mb-2">Minhas Reservas</h1>
-        <p class="text-slate-500 max-w-md mb-2">Esta funcionalidade está em desenvolvimento.</p>
-        <span class="inline-flex items-center gap-1 px-3 py-1 bg-sky-50 text-sky-700 rounded-full text-sm font-medium">US09 - Minhas reservas</span>
+
+        <!-- Loading -->
+        <div v-if="loading" class="flex items-center justify-center py-12">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </div>
+
+        <template v-else>
+          <!-- Filters -->
+          <div class="flex items-center gap-2 mb-6 overflow-x-auto pb-2">
+            <button
+              v-for="f in filterOptions"
+              :key="f.value"
+              @click="activeFilter = f.value; page = 1; fetchReservations()"
+              :class="['px-4 py-2 rounded-xl text-sm font-medium transition-all whitespace-nowrap', activeFilter === f.value ? 'bg-primary text-white shadow-sm' : 'bg-white text-slate-600 border border-slate-200 hover:bg-slate-50']"
+            >
+              {{ f.label }}
+            </button>
+          </div>
+
+          <!-- Empty -->
+          <div v-if="reservations.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
+            <div class="w-20 h-20 bg-sky-100 rounded-full flex items-center justify-center mb-6">
+              <span class="material-symbols-outlined text-4xl text-sky-500">event_busy</span>
+            </div>
+            <h2 class="text-xl font-bold text-cyan-900 mb-2">Nenhuma reserva encontrada</h2>
+            <p class="text-slate-500 max-w-md mb-6">
+              {{ activeFilter === 'future' ? 'Você não tem reservas futuras.' : activeFilter === 'past' ? 'Nenhuma reserva anterior.' : 'Nenhuma reserva com este status.' }}
+            </p>
+            <router-link
+              to="/resident/reservations/new"
+              class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-xl hover:brightness-90 transition-all font-semibold"
+            >
+              <span class="material-symbols-outlined">add</span>
+              Nova Reserva
+            </router-link>
+          </div>
+
+          <!-- Reservations List -->
+          <div v-else class="space-y-3">
+            <div
+              v-for="res in reservations"
+              :key="res.id"
+              class="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden transition-all"
+            >
+              <!-- Card Header -->
+              <div
+                @click="toggleExpand(res.id)"
+                class="flex items-center gap-4 p-4 md:p-5 cursor-pointer hover:bg-slate-50/50 transition-colors"
+              >
+                <div class="w-11 h-11 bg-primary/10 rounded-xl flex items-center justify-center shrink-0">
+                  <span class="material-symbols-outlined text-primary">{{ res.commonArea?.icon || 'home_work' }}</span>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <h3 class="font-bold text-cyan-900 truncate">{{ res.commonArea?.name || 'Área' }}</h3>
+                  <p class="text-sm text-slate-500">{{ formatResDate(res.startTime) }} &middot; {{ formatTime(res.startTime) }} - {{ formatTime(res.endTime) }}</p>
+                </div>
+                <div class="flex items-center gap-3 shrink-0">
+                  <span :class="['px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wider', statusClass(res.status)]">
+                    {{ statusLabel(res.status) }}
+                  </span>
+                  <span class="material-symbols-outlined text-slate-400 transition-transform" :class="expandedId === res.id ? 'rotate-180' : ''">
+                    expand_more
+                  </span>
+                </div>
+              </div>
+
+              <!-- Expanded Content -->
+              <div v-if="expandedId === res.id" class="border-t border-slate-100 px-4 md:px-5 py-4 bg-slate-50/50">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <!-- Details -->
+                  <div class="space-y-2 text-sm">
+                    <div class="flex items-center gap-2 text-slate-500">
+                      <span class="material-symbols-outlined text-[16px]">calendar_month</span>
+                      <span>{{ formatResDate(res.startTime) }}</span>
+                    </div>
+                    <div class="flex items-center gap-2 text-slate-500">
+                      <span class="material-symbols-outlined text-[16px]">schedule</span>
+                      <span>{{ formatTime(res.startTime) }} - {{ formatTime(res.endTime) }}</span>
+                    </div>
+                    <div class="flex items-center gap-2 text-slate-500">
+                      <span class="material-symbols-outlined text-[16px]">group</span>
+                      <span>{{ res.commonArea?.capacity || 'N/D' }} pessoas</span>
+                    </div>
+                    <div v-if="res.canceledAt" class="flex items-center gap-2 text-red-500">
+                      <span class="material-symbols-outlined text-[16px]">cancel</span>
+                      <span>Cancelado em {{ formatResDate(res.canceledAt) }}</span>
+                    </div>
+                  </div>
+
+                  <!-- Actions -->
+                  <div class="flex flex-col gap-2 justify-start items-end">
+                    <button
+                      v-if="res.status === 'PENDING' || res.status === 'APPROVED'"
+                      @click="confirmCancel(res)"
+                      class="inline-flex items-center gap-1.5 px-4 py-2 bg-red-50 text-red-700 border border-red-200 rounded-xl hover:bg-red-100 transition-all text-sm font-medium"
+                    >
+                      <span class="material-symbols-outlined text-[16px]">cancel</span>
+                      Cancelar reserva
+                    </button>
+                    <router-link
+                      :to="`/resident/availability?area=${res.commonAreaId}&date=${res.startTime.split('T')[0]}`"
+                      class="inline-flex items-center gap-1.5 px-4 py-2 bg-white text-primary border border-primary/20 rounded-xl hover:bg-primary/5 transition-all text-sm font-medium"
+                    >
+                      <span class="material-symbols-outlined text-[16px]">calendar_month</span>
+                      Ver disponibilidade
+                    </router-link>
+                  </div>
+                </div>
+
+                <!-- Timeline -->
+                <div v-if="timelineLoading === res.id" class="flex items-center justify-center py-4">
+                  <div class="animate-spin h-5 w-5 border-2 border-primary border-t-transparent rounded-full"></div>
+                </div>
+                <div v-else-if="timelines[res.id]" class="mt-4 pt-4 border-t border-slate-100">
+                  <p class="text-xs font-semibold text-slate-400 mb-2 uppercase tracking-wider">Disponibilidade do dia</p>
+                  <div class="space-y-1">
+                    <div
+                      v-for="(slot, idx) in timelines[res.id]"
+                      :key="idx"
+                      class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm"
+                      :class="slot.available ? 'bg-emerald-50/50' : 'bg-red-50/50'"
+                    >
+                      <span class="material-symbols-outlined text-[16px]" :class="slot.available ? 'text-emerald-400' : 'text-red-400'">
+                        {{ slot.available ? 'check_circle' : 'block' }}
+                      </span>
+                      <span class="font-medium" :class="slot.available ? 'text-emerald-700' : 'text-red-700'">
+                        {{ slot.start }} - {{ slot.end }}
+                      </span>
+                      <span v-if="!slot.available" class="text-xs text-red-400 ml-auto">{{ statusLabel(slot.status) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Pagination -->
+            <div v-if="totalPages > 1" class="flex items-center justify-center gap-2 pt-4">
+              <button
+                v-for="p in totalPages"
+                :key="p"
+                @click="goToPage(p)"
+                :class="['min-w-[36px] h-9 rounded-lg text-sm font-medium transition-all', p === page ? 'bg-primary text-white shadow-sm' : 'text-slate-600 hover:bg-slate-100']"
+              >
+                {{ p }}
+              </button>
+            </div>
+          </div>
+        </template>
       </div>
     </main>
 
-    <!-- Mobile Overlay -->
-    <div 
-      v-if="sidebarOpen" 
-      class="fixed inset-0 bg-black/50 z-40 md:hidden"
-      @click="sidebarOpen = false"
-    ></div>
+    <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
 import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
@@ -46,18 +198,207 @@ import { authService } from '@/modules/auth/services/auth.service'
 import { http } from '@/api/http'
 import { useSidebar } from '@/modules/shared/composables/useSidebar'
 
+interface CommonAreaInfo {
+  id: string
+  name: string
+  icon: string | null
+  capacity: number | null
+}
+
+interface Reservation {
+  id: string
+  residentId: string
+  commonAreaId: string
+  startTime: string
+  endTime: string
+  status: string
+  notes: string | null
+  canceledById: string | null
+  canceledAt: string | null
+  createdAt: string
+  updatedAt: string
+  commonArea: CommonAreaInfo | null
+}
+
+interface ListResponse {
+  reservations: Reservation[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+interface TimeSlot {
+  start: string
+  end: string
+  available: boolean
+  status?: string
+}
+
 const router = useRouter()
 const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
 
 const user = authService.getUser()
 const userName = ref(user?.name || '')
 
-const handleLogout = async () => {
+const reservations = ref<Reservation[]>([])
+const loading = ref(true)
+const page = ref(1)
+const totalPages = ref(1)
+const activeFilter = ref('future')
+const expandedId = ref<string | null>(null)
+const timelines = ref<Record<string, TimeSlot[]>>({})
+const timelineLoading = ref<string | null>(null)
+
+const filterOptions = [
+  { label: 'Próximas', value: 'future' },
+  { label: 'Anteriores', value: 'past' },
+  { label: 'Pendentes', value: 'PENDING' },
+  { label: 'Confirmadas', value: 'APPROVED' },
+  { label: 'Canceladas', value: 'CANCELED' },
+]
+
+function getFilterParams(filter: string): Record<string, string> {
+  const today = new Date()
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayStr = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`
+
+  switch (filter) {
+    case 'future': return { from: todayStr, status: 'PENDING,APPROVED' }
+    case 'past': return { to: yesterdayStr }
+    default: return { status: filter }
+  }
+}
+
+function statusClass(status: string): string {
+  const map: Record<string, string> = {
+    PENDING: 'bg-amber-50 text-amber-700',
+    APPROVED: 'bg-emerald-50 text-emerald-700',
+    REJECTED: 'bg-red-50 text-red-700',
+    CANCELED: 'bg-slate-100 text-slate-500',
+  }
+  return map[status] || 'bg-slate-100 text-slate-500'
+}
+
+function statusLabel(status: string): string {
+  const map: Record<string, string> = {
+    PENDING: 'Pendente',
+    APPROVED: 'Confirmada',
+    REJECTED: 'Rejeitada',
+    CANCELED: 'Cancelada',
+  }
+  return map[status] || status
+}
+
+function formatResDate(dateStr: string): string {
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'long', year: 'numeric' })
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+}
+
+function getDateStr(dateStr: string): string {
+  return dateStr.split('T')[0]
+}
+
+async function fetchReservations() {
+  loading.value = true
   try {
-    await http.post('/auth/logout')
-  } catch { /* ignora */ }
+    const params: Record<string, any> = { page: page.value, limit: 10 }
+    const filterParams = getFilterParams(activeFilter.value)
+    Object.assign(params, filterParams)
+    const res = await http.get('/reservations', { params })
+    const data = (res.data as any).data as ListResponse
+    reservations.value = data.reservations
+    totalPages.value = data.totalPages
+  } catch {
+    reservations.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function fetchTimeline(reservation: Reservation) {
+  const id = reservation.id
+  timelineLoading.value = id
+  try {
+    const dateStr = getDateStr(reservation.startTime)
+    const res = await http.get(`/common-areas/${reservation.commonAreaId}/availability`, {
+      params: { date: dateStr },
+    })
+    const availability = (res.data as any).data as any
+    const slots: TimeSlot[] = []
+    let cursor = availability.openTime
+    const sorted = [...(availability.conflicts || [])].sort((a: any, b: any) => a.startTime.localeCompare(b.startTime))
+    for (const c of sorted) {
+      if (cursor < c.startTime) {
+        slots.push({ start: cursor, end: c.startTime, available: true })
+      }
+      slots.push({ start: c.startTime, end: c.endTime, available: false, status: c.status })
+      cursor = c.endTime > cursor ? c.endTime : cursor
+    }
+    if (cursor < availability.closeTime) {
+      slots.push({ start: cursor, end: availability.closeTime, available: true })
+    }
+    timelines.value[id] = slots
+  } catch {
+    timelines.value[id] = []
+  } finally {
+    timelineLoading.value = null
+  }
+}
+
+function toggleExpand(id: string) {
+  if (expandedId.value === id) {
+    expandedId.value = null
+    return
+  }
+  expandedId.value = id
+  const res = reservations.value.find((r) => r.id === id)
+  if (res && !timelines.value[id]) {
+    fetchTimeline(res)
+  }
+}
+
+async function confirmCancel(res: Reservation) {
+  const msg = `Tem certeza que deseja cancelar a reserva em "${res.commonArea?.name}" no dia ${formatResDate(res.startTime)}?`
+  if (!confirm(msg)) return
+  try {
+    await http.patch(`/reservations/${res.id}/cancel`)
+    timelines.value = {}
+    await fetchReservations()
+  } catch {
+    alert('Erro ao cancelar reserva.')
+  }
+}
+
+function goToPage(p: number) {
+  page.value = p
+  fetchReservations()
+}
+
+const handleQuickAction = (actionId: string) => {
+  if (actionId === 'new-reservation') router.push('/resident/reservations/new')
+}
+
+const handleLogout = async () => {
+  try { await http.post('/auth/logout') } catch {}
   authService.logout()
   router.push('/')
 }
 
+onMounted(() => {
+  fetchReservations()
+})
 </script>
+
+<style scoped>
+.material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+</style>

--- a/apps/web/src/modules/resident/pages/NewReservationPage.vue
+++ b/apps/web/src/modules/resident/pages/NewReservationPage.vue
@@ -1,49 +1,691 @@
 <template>
   <div class="flex min-h-screen bg-surface text-on-surface">
-    <SideNavBar 
-      role="RESIDENT" 
+    <SideNavBar
+      role="RESIDENT"
       :userName="userName"
       :collapsed="sidebarCollapsed"
       @toggle-collapse="toggleCollapse"
       @logout="handleLogout"
       @cta-click="handleQuickAction"
-      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" 
+      :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']"
     />
+
     <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
-      <TopAppBar 
-        :userName="userName" 
+      <TopAppBar
+        :userName="userName"
         userRole="RESIDENT"
-        @toggle-sidebar="sidebarOpen = !sidebarOpen" 
+        @toggle-sidebar="sidebarOpen = !sidebarOpen"
       />
-      <div class="flex-1 p-4 md:p-6 lg:p-8 flex flex-col items-center justify-center text-center">
-        <div class="w-20 h-20 bg-sky-100 rounded-full flex items-center justify-center mb-6">
-          <span class="material-symbols-outlined text-4xl text-sky-500">construction</span>
+
+      <div class="flex-1 p-4 md:p-6 lg:p-8">
+        <!-- Header -->
+        <div class="mb-6 md:mb-8">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
+              <span class="material-symbols-outlined text-primary">add_circle</span>
+            </div>
+            <h1 class="text-2xl font-bold text-cyan-900">Nova Reserva</h1>
+          </div>
+          <p class="text-slate-500 ml-[52px]">Selecione área, dia e horário para reservar</p>
         </div>
-        <h1 class="text-2xl font-bold text-cyan-900 mb-2">Nova Reserva</h1>
-        <p class="text-slate-500 max-w-md mb-2">Esta funcionalidade está em desenvolvimento.</p>
-        <span class="inline-flex items-center gap-1 px-3 py-1 bg-sky-50 text-sky-700 rounded-full text-sm font-medium">US07 - Realizar reserva de área comum</span>
+
+        <!-- Loading -->
+        <div v-if="loadingAreas" class="flex items-center justify-center py-12">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        </div>
+
+        <!-- Success -->
+        <div v-else-if="success" class="bg-emerald-50 border border-emerald-200 rounded-2xl p-8 text-center max-w-lg mx-auto">
+          <div class="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span class="material-symbols-outlined text-3xl text-emerald-600">check_circle</span>
+          </div>
+          <h2 class="text-xl font-bold text-emerald-800 mb-2">Reserva Confirmada!</h2>
+          <p class="text-emerald-600 mb-6">{{ successArea }} — {{ successDate }} das {{ successStart }} às {{ successEnd }}</p>
+          <div class="flex items-center justify-center gap-3">
+            <router-link to="/resident/reservations" class="px-6 py-2.5 bg-emerald-600 text-white rounded-xl hover:brightness-90 transition-all font-semibold text-sm">Minhas Reservas</router-link>
+            <button @click="resetForm" class="px-6 py-2.5 border border-emerald-200 text-emerald-700 rounded-xl hover:bg-emerald-50 transition-all font-medium text-sm">Nova Reserva</button>
+          </div>
+        </div>
+
+        <template v-else>
+          <!-- Area Selector -->
+          <div class="bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm mb-6">
+            <div class="flex items-center gap-4 flex-wrap">
+              <div class="flex-1 min-w-[200px]">
+                <label class="block text-sm font-medium text-slate-700 mb-1.5">Área Comum</label>
+                <select
+                  v-model="selectedAreaId"
+                  @change="onAreaChange"
+                  class="w-full max-w-xs px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                >
+                  <option value="" disabled>Selecione uma área</option>
+                  <option v-for="a in areas" :key="a.id" :value="a.id">{{ a.name }}</option>
+                </select>
+              </div>
+              <div v-if="selectedArea" class="text-sm text-slate-500 flex items-center gap-4">
+                <span class="flex items-center gap-1">
+                  <span class="material-symbols-outlined text-[16px]">schedule</span>
+                  {{ selectedArea.openTime }} - {{ selectedArea.closeTime }}
+                </span>
+                <span v-if="selectedArea.capacity" class="flex items-center gap-1">
+                  <span class="material-symbols-outlined text-[16px]">group</span>
+                  {{ selectedArea.capacity }} pessoas
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="grid grid-cols-1 xl:grid-cols-5 gap-6">
+            <!-- Calendar -->
+            <div class="xl:col-span-3 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <div class="flex items-center justify-between mb-4">
+                <button @click="prevMonth" class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500">
+                  <span class="material-symbols-outlined">chevron_left</span>
+                </button>
+                <span class="font-bold text-cyan-900">{{ monthLabel }}</span>
+                <button @click="nextMonth" class="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500">
+                  <span class="material-symbols-outlined">chevron_right</span>
+                </button>
+              </div>
+
+              <div class="grid grid-cols-7 gap-1 mb-1">
+                <div v-for="day in dayLabels" :key="day" class="text-center text-xs font-semibold text-slate-400 py-1.5">{{ day }}</div>
+              </div>
+
+              <div class="grid grid-cols-7 gap-1">
+                <div
+                  v-for="(day, idx) in calendarDays"
+                  :key="idx"
+                  @click="onDayClick(day)"
+                  class="relative rounded-lg flex flex-col items-center justify-center text-sm transition-all cursor-pointer min-h-[44px]"
+                  :class="dayCellClass(day)"
+                >
+                  <span class="font-medium leading-none" :class="dayTextClass(day)">{{ day.number }}</span>
+                </div>
+              </div>
+
+              <div v-if="selectedArea" class="mt-4 pt-3 border-t border-slate-100 flex items-center gap-4 text-xs">
+                <span class="flex items-center gap-1.5"><span class="w-3 h-3 rounded-sm bg-emerald-400 inline-block"></span> Disponível</span>
+                <span class="flex items-center gap-1.5"><span class="w-3 h-3 rounded-sm bg-red-400 inline-block"></span> Ocupado</span>
+                <span class="flex items-center gap-1.5"><span class="w-3 h-3 rounded-sm bg-slate-100 border border-slate-200 inline-block"></span> Fechado</span>
+                <span class="flex items-center gap-1.5"><span class="w-3 h-3 rounded-sm bg-primary/20 inline-block"></span> Selecionado</span>
+              </div>
+            </div>
+
+            <!-- Timeline + Time Picker Panel -->
+            <div class="xl:col-span-2 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <!-- Empty states -->
+              <template v-if="!selectedAreaId">
+                <div class="flex flex-col items-center justify-center h-full py-8 text-center">
+                  <span class="material-symbols-outlined text-4xl text-slate-300 mb-3">pin_drop</span>
+                  <p class="text-slate-400 text-sm">Escolha uma área comum</p>
+                </div>
+              </template>
+
+              <template v-else-if="!selectedDate">
+                <div class="flex flex-col items-center justify-center h-full py-8 text-center">
+                  <span class="material-symbols-outlined text-4xl text-slate-300 mb-3">calendar_month</span>
+                  <p class="text-slate-400 text-sm">Clique num dia do calendário</p>
+                </div>
+              </template>
+
+              <!-- Loading -->
+              <template v-if="checking">
+                <div class="flex items-center justify-center py-8">
+                  <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+                </div>
+              </template>
+
+              <!-- Error -->
+              <template v-if="checkError">
+                <div class="text-center py-4">
+                  <span class="material-symbols-outlined text-3xl text-red-300 mb-2">error_outline</span>
+                  <p class="text-sm text-red-600">{{ checkError }}</p>
+                </div>
+              </template>
+
+              <!-- Result -->
+              <template v-if="result">
+                <h3 class="font-bold text-cyan-900 text-lg mb-1">{{ formatDate(result.date) }}</h3>
+                <p class="text-xs text-slate-400 mb-4">{{ result.openTime }} - {{ result.closeTime }} • {{ result.conflicts.length }} reserva{{ result.conflicts.length !== 1 ? 's' : '' }}</p>
+
+                <!-- Visual Timeline -->
+                <div class="relative mb-4 bg-slate-50 rounded-xl p-3">
+                  <!-- Time labels + bar -->
+                  <div class="flex items-center gap-2 mb-2 text-xs text-slate-400">
+                    <span>{{ result.openTime }}</span>
+                    <div class="flex-1 h-1.5 bg-slate-200 rounded-full relative overflow-hidden">
+                      <!-- Conflict blocks -->
+                      <div
+                        v-for="(c, idx) in result.conflicts"
+                        :key="idx"
+                        class="absolute top-0 h-full bg-red-400 rounded-full opacity-80"
+                        :style="conflictBarStyle(c)"
+                      ></div>
+                      <!-- Selected range -->
+                      <div
+                        v-if="selectedStart && selectedEnd"
+                        class="absolute top-0 h-full rounded-full transition-all"
+                        :class="rangeValid ? 'bg-emerald-400' : 'bg-red-500'"
+                        :style="selectedBarStyle"
+                      ></div>
+                    </div>
+                    <span>{{ result.closeTime }}</span>
+                  </div>
+                  <!-- Conflict labels -->
+                  <div v-for="(c, idx) in result.conflicts" :key="idx" class="text-xs text-red-500 mb-0.5 flex items-center gap-1">
+                    <span class="w-1.5 h-1.5 rounded-full bg-red-400 inline-block"></span>
+                    {{ c.startTime }} - {{ c.endTime }}
+                    <span class="text-red-300">({{ statusLabel(c.status) }})</span>
+                  </div>
+                  <!-- Selected range label -->
+                  <div v-if="selectedStart && selectedEnd" class="mt-1 text-xs flex items-center gap-1" :class="rangeValid ? 'text-emerald-600' : 'text-red-600'">
+                    <span class="w-1.5 h-1.5 rounded-full inline-block" :class="rangeValid ? 'bg-emerald-400' : 'bg-red-500'"></span>
+                    {{ selectedStart }} - {{ selectedEnd }}
+                    <span class="font-semibold">{{ rangeValid ? 'Disponível' : 'Conflito' }}</span>
+                  </div>
+                </div>
+
+                <!-- Time Pickers -->
+                <div class="grid grid-cols-2 gap-3 mb-4">
+                  <div>
+                    <label class="block text-xs font-medium text-slate-600 mb-1">Início</label>
+                    <select
+                      v-model="selectedStart"
+                      @change="onTimeChange"
+                      class="w-full px-2.5 py-2 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                    >
+                      <option value="" disabled>Selecione</option>
+                      <option v-for="t in timeOptions" :key="t" :value="t" :disabled="t >= result.closeTime">{{ t }}</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label class="block text-xs font-medium text-slate-600 mb-1">Fim</label>
+                    <select
+                      v-model="selectedEnd"
+                      @change="onTimeChange"
+                      class="w-full px-2.5 py-2 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                    >
+                      <option value="" disabled>Selecione</option>
+                      <option v-for="t in endTimeOptions" :key="t" :value="t">{{ t }}</option>
+                    </select>
+                  </div>
+                </div>
+
+                <!-- Validation messages -->
+                <p v-if="selectedStart && !selectedEnd" class="text-xs text-slate-400 mb-3">
+                  Mínimo de 2 horas de duração
+                </p>
+                <p v-if="selectedStart && selectedEnd && !rangeValid" class="text-sm text-red-600 mb-3">
+                  Este horário conflita com {{ conflictCount }} reserva{{ conflictCount !== 1 ? 's' : '' }} existente{{ conflictCount !== 1 ? 's' : '' }}
+                </p>
+
+                <!-- Confirm Button -->
+                <button
+                  v-if="rangeValid"
+                  @click="showConfirm = true"
+                  class="w-full inline-flex items-center justify-center gap-2 px-6 py-2.5 bg-primary text-white rounded-xl hover:brightness-90 transition-all font-semibold text-sm"
+                >
+                  <span class="material-symbols-outlined text-[18px]">event_available</span>
+                  Reservar {{ selectedStart }} - {{ selectedEnd }}
+                </button>
+              </template>
+            </div>
+          </div>
+
+          <!-- Confirm Dialog -->
+          <div v-if="showConfirm" class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" @click.self="showConfirm = false">
+            <div class="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
+              <div class="flex items-center gap-3 mb-4">
+                <div class="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
+                  <span class="material-symbols-outlined text-primary">event_available</span>
+                </div>
+                <h2 class="text-lg font-bold text-cyan-900">Confirmar Reserva</h2>
+              </div>
+
+              <div class="bg-slate-50 rounded-xl p-4 space-y-2 mb-4 text-sm">
+                <div class="flex justify-between"><span class="text-slate-500">Área</span><span class="font-medium text-cyan-900">{{ selectedArea?.name }}</span></div>
+                <div class="flex justify-between"><span class="text-slate-500">Data</span><span class="font-medium text-cyan-900">{{ formatDate(selectedDate) }}</span></div>
+                <div class="flex justify-between"><span class="text-slate-500">Horário</span><span class="font-medium text-cyan-900">{{ selectedStart }} às {{ selectedEnd }}</span></div>
+              </div>
+
+              <div class="mb-4">
+                <label class="block text-sm font-medium text-slate-700 mb-1">Observações <span class="text-slate-400">(opcional)</span></label>
+                <textarea
+                  v-model="notes"
+                  rows="2"
+                  placeholder="Alguma observação para a reserva..."
+                  class="w-full px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all resize-none"
+                ></textarea>
+              </div>
+
+              <p v-if="formError" class="text-sm text-red-600 mb-3">{{ formError }}</p>
+
+              <div class="flex items-center gap-3">
+                <button
+                  @click="submitReservation"
+                  :disabled="submitting"
+                  class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 bg-primary text-white rounded-xl hover:brightness-90 transition-all font-semibold text-sm disabled:opacity-50"
+                >
+                  <span v-if="submitting" class="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"></span>
+                  {{ submitting ? 'Reservando...' : 'Confirmar' }}
+                </button>
+                <button @click="showConfirm = false" class="px-4 py-2.5 border border-slate-200 text-slate-600 rounded-xl hover:bg-slate-50 transition-all text-sm font-medium">Cancelar</button>
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
     </main>
+
     <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
   </div>
 </template>
+
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
 import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
 import { authService } from '@/modules/auth/services/auth.service'
 import { http } from '@/api/http'
 import { useSidebar } from '@/modules/shared/composables/useSidebar'
+
+interface CommonArea {
+  id: string
+  name: string
+  description: string | null
+  capacity: number | null
+  openTime: string
+  closeTime: string
+  operatingDays: number[] | null
+  requiresApproval: boolean
+  icon: string | null
+  isUnderMaintenance: boolean
+}
+
+interface Conflict {
+  startTime: string
+  endTime: string
+  status: string
+}
+
+interface AvailabilityResult {
+  available: boolean
+  date: string
+  commonAreaId: string
+  commonAreaName: string
+  openTime: string
+  closeTime: string
+  startTime?: string
+  endTime?: string
+  conflicts: Conflict[]
+}
+
+interface CalendarDay {
+  type: 'prev' | 'current' | 'next'
+  number: number
+  dateStr: string
+  isToday: boolean
+  past: boolean
+  isOperating: boolean
+}
+
 const router = useRouter()
+const route = useRoute()
 const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
+
 const user = authService.getUser()
 const userName = ref(user?.name || '')
-const handleQuickAction = () => {}
+
+const areas = ref<CommonArea[]>([])
+const loadingAreas = ref(true)
+const selectedAreaId = ref('')
+const selectedDate = ref('')
+const checking = ref(false)
+const checkError = ref<string | null>(null)
+const result = ref<AvailabilityResult | null>(null)
+const selectedStart = ref('')
+const selectedEnd = ref('')
+const showConfirm = ref(false)
+const notes = ref('')
+const submitting = ref(false)
+const formError = ref<string | null>(null)
+
+const success = ref(false)
+const successArea = ref('')
+const successDate = ref('')
+const successStart = ref('')
+const successEnd = ref('')
+
+const currentMonth = ref(new Date().getMonth())
+const currentYear = ref(new Date().getFullYear())
+const busyDates = ref<Set<string>>(new Set())
+
+const dayLabels = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
+
+const selectedArea = computed(() => {
+  if (!selectedAreaId.value) return null
+  return areas.value.find((a) => a.id === selectedAreaId.value) || null
+})
+
+const monthLabel = computed(() => {
+  const d = new Date(currentYear.value, currentMonth.value, 1)
+  return d.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })
+})
+
+const operatingDaysSet = computed(() => {
+  const area = selectedArea.value
+  if (!area?.operatingDays) return new Set<number>()
+  const days = Array.isArray(area.operatingDays) ? area.operatingDays : []
+  const map: Record<number, number> = { 0: 7, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6 }
+  return new Set(days.map((d) => map[d] ?? d))
+})
+
+/** Check if a given time on a given date is already in the past */
+function isTimePast(time: string, date: string): boolean {
+  const todayStr = fmtDate(new Date())
+  if (date !== todayStr) return false
+  const now = new Date()
+  const [h, m] = time.split(':').map(Number)
+  return h * 60 + m <= now.getHours() * 60 + now.getMinutes()
+}
+
+/** Generate 30-min time options from openTime to closeTime */
+const timeOptions = computed<string[]>(() => {
+  if (!result.value) return []
+  const times: string[] = []
+  const [openH, openM] = result.value.openTime.split(':').map(Number)
+  const [closeH, closeM] = result.value.closeTime.split(':').map(Number)
+  const start = openH * 60 + openM
+  const end = closeH * 60 + closeM
+  for (let m = start; m <= end; m += 30) {
+    const h = Math.floor(m / 60)
+    const min = m % 60
+    const t = `${String(h).padStart(2, '0')}:${String(min).padStart(2, '0')}`
+    if (!isTimePast(t, selectedDate.value)) {
+      times.push(t)
+    }
+  }
+  return times
+})
+
+const endTimeOptions = computed<string[]>(() => {
+  if (!selectedStart.value) return []
+  const [startH, startM] = selectedStart.value.split(':').map(Number)
+  const minEnd = startH * 60 + startM + 120
+  return timeOptions.value.filter((t) => {
+    const [h, m] = t.split(':').map(Number)
+    return h * 60 + m >= minEnd
+  })
+})
+
+const rangeValid = computed(() => {
+  if (!selectedStart.value || !selectedEnd.value || !result.value) return false
+  if (selectedStart.value >= selectedEnd.value) return false
+  const conflicts = result.value.conflicts
+  for (const c of conflicts) {
+    if (selectedStart.value < c.endTime && selectedEnd.value > c.startTime) return false
+  }
+  return true
+})
+
+const conflictCount = computed(() => {
+  if (!selectedStart.value || !selectedEnd.value || !result.value) return 0
+  const conflicts = result.value.conflicts
+  let count = 0
+  for (const c of conflicts) {
+    if (selectedStart.value < c.endTime && selectedEnd.value > c.startTime) count++
+  }
+  return count
+})
+
+function timeToPercent(time: string, open: string, close: string): number {
+  const toMins = (t: string) => { const [h, m] = t.split(':').map(Number); return h * 60 + m }
+  const total = toMins(close) - toMins(open)
+  if (total <= 0) return 0
+  return ((toMins(time) - toMins(open)) / total) * 100
+}
+
+function conflictBarStyle(c: Conflict): Record<string, string> {
+  if (!result.value) return {}
+  const left = timeToPercent(c.startTime, result.value.openTime, result.value.closeTime)
+  const right = timeToPercent(c.endTime, result.value.openTime, result.value.closeTime)
+  return { left: `${left}%`, width: `${right - left}%` }
+}
+
+const selectedBarStyle = computed(() => {
+  if (!result.value || !selectedStart.value || !selectedEnd.value) return {}
+  const left = timeToPercent(selectedStart.value, result.value.openTime, result.value.closeTime)
+  const right = timeToPercent(selectedEnd.value, result.value.openTime, result.value.closeTime)
+  return { left: `${left}%`, width: `${right - left}%` }
+})
+
+const calendarDays = computed(() => {
+  const year = currentYear.value
+  const month = currentMonth.value
+  const todayDate = new Date()
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+  const startPad = firstDay.getDay()
+  const daysInMonth = lastDay.getDate()
+  const daysInPrev = new Date(year, month, 0).getDate()
+  const days: CalendarDay[] = []
+
+  for (let i = startPad - 1; i >= 0; i--) {
+    const dt = new Date(year, month - 1, daysInPrev - i)
+    days.push({ type: 'prev', number: daysInPrev - i, dateStr: fmtDate(dt), isToday: false, past: true, isOperating: false })
+  }
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dt = new Date(year, month, day)
+    const ds = fmtDate(dt)
+    const isToday = ds === fmtDate(todayDate)
+    const past = dt < new Date(todayDate.getFullYear(), todayDate.getMonth(), todayDate.getDate())
+    const dow = ((dt.getDay() + 6) % 7) + 1
+    days.push({ type: 'current', number: day, dateStr: ds, isToday, past, isOperating: operatingDaysSet.value.has(dow) })
+  }
+
+  const remaining = 42 - days.length
+  for (let day = 1; day <= remaining; day++) {
+    const dt = new Date(year, month + 1, day)
+    days.push({ type: 'next', number: day, dateStr: fmtDate(dt), isToday: false, past: false, isOperating: false })
+  }
+
+  return days
+})
+
+function fmtDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function dayCellClass(day: CalendarDay): Record<string, boolean> {
+  const isSel = selectedDate.value === day.dateStr
+  const isBusy = busyDates.value.has(day.dateStr)
+  const isFree = day.type === 'current' && !day.past && day.isOperating && !isBusy
+
+  return {
+    'opacity-20 cursor-default': day.type !== 'current' || (day.type === 'current' && day.past),
+    'bg-slate-100 text-slate-400 cursor-default': day.type === 'current' && !day.past && !day.isOperating,
+    'bg-emerald-400 text-white hover:brightness-110': isFree && !isSel,
+    'bg-red-400 text-white hover:brightness-110': isBusy && !isSel,
+    'bg-primary text-white ring-2 ring-primary/40': isSel,
+  }
+}
+
+function dayTextClass(day: CalendarDay): string {
+  if (day.dateStr === selectedDate.value) return 'text-white'
+  if (day.type === 'current' && !day.past && day.isOperating) return 'text-white'
+  return ''
+}
+
+function prevMonth() {
+  if (currentMonth.value === 0) { currentMonth.value = 11; currentYear.value-- }
+  else { currentMonth.value-- }
+  if (selectedAreaId.value) fetchBusyDays()
+}
+
+function nextMonth() {
+  if (currentMonth.value === 11) { currentMonth.value = 0; currentYear.value++ }
+  else { currentMonth.value++ }
+  if (selectedAreaId.value) fetchBusyDays()
+}
+
+function onDayClick(day: CalendarDay) {
+  if (day.type !== 'current' || day.past || !day.isOperating || !selectedAreaId.value) return
+  selectedDate.value = day.dateStr
+  selectedStart.value = ''
+  selectedEnd.value = ''
+  showConfirm.value = false
+  notes.value = ''
+  checkAvailability()
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T12:00:00Z')
+  return d.toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: 'long' })
+}
+
+function statusLabel(status?: string): string {
+  const map: Record<string, string> = { PENDING: 'Pendente', APPROVED: 'Confirmada', CANCELED: 'Cancelada', REJECTED: 'Rejeitada' }
+  return map[status || ''] || status || ''
+}
+
+async function fetchBusyDays() {
+  if (!selectedAreaId.value) return
+  try {
+    const res = await http.get(`/common-areas/${selectedAreaId.value}/busy-days`, {
+      params: { year: currentYear.value, month: currentMonth.value + 1 },
+    })
+    busyDates.value = new Set(res.data.data.busyDates)
+  } catch {
+    busyDates.value = new Set()
+  }
+}
+
+function onAreaChange() {
+  selectedDate.value = ''
+  result.value = null
+  checkError.value = null
+  busyDates.value = new Set()
+  selectedStart.value = ''
+  selectedEnd.value = ''
+  showConfirm.value = false
+  notes.value = ''
+  fetchBusyDays()
+}
+
+function onTimeChange() {
+  showConfirm.value = false
+}
+
+function clearEndIfInvalid() {
+  if (!selectedEnd.value) return
+  const valid = endTimeOptions.value.find((t) => t === selectedEnd.value)
+  if (!valid) selectedEnd.value = ''
+}
+
+watch(selectedStart, () => {
+  clearEndIfInvalid()
+})
+
+async function checkAvailability() {
+  checkError.value = null
+  result.value = null
+  checking.value = true
+  try {
+    const res = await http.get(`/common-areas/${selectedAreaId.value}/availability`, {
+      params: { date: selectedDate.value },
+    })
+    result.value = res.data.data as AvailabilityResult
+  } catch (err: any) {
+    checkError.value = err?.response?.data?.message || err?.message || 'Erro ao verificar disponibilidade.'
+  } finally {
+    checking.value = false
+  }
+}
+
+async function submitReservation() {
+  formError.value = null
+  submitting.value = true
+  try {
+    const body = {
+      commonAreaId: selectedAreaId.value,
+      date: selectedDate.value,
+      startTime: selectedStart.value,
+      endTime: selectedEnd.value,
+      notes: notes.value || undefined,
+    }
+    const res = await http.post('/reservations', body)
+    const data = (res.data as any).data as any
+
+    successArea.value = selectedArea.value?.name || ''
+    successDate.value = formatDate(selectedDate.value)
+    successStart.value = selectedStart.value
+    successEnd.value = selectedEnd.value
+    success.value = true
+  } catch (err: any) {
+    formError.value = err?.response?.data?.message || err?.message || 'Erro ao criar reserva.'
+  } finally {
+    submitting.value = false
+  }
+}
+
+function resetForm() {
+  selectedAreaId.value = ''
+  selectedDate.value = ''
+  result.value = null
+  selectedStart.value = ''
+  selectedEnd.value = ''
+  showConfirm.value = false
+  notes.value = ''
+  formError.value = null
+  success.value = false
+  busyDates.value = new Set()
+}
+
+function applyQueryParams() {
+  const q = route.query
+  if (q.areaId) selectedAreaId.value = q.areaId as string
+  if (q.date) selectedDate.value = q.date as string
+  if (q.startTime) selectedStart.value = q.startTime as string
+  if (q.endTime) selectedEnd.value = q.endTime as string
+  if (selectedAreaId.value && selectedDate.value) {
+    setTimeout(() => { fetchBusyDays(); checkAvailability() }, 0)
+  }
+}
+
+async function fetchAreas() {
+  loadingAreas.value = true
+  try {
+    const res = await http.get('/common-areas', { params: { limit: 50 } })
+    areas.value = ((res.data as any).data as any).commonAreas.filter((a: CommonArea) => !a.isUnderMaintenance)
+    applyQueryParams()
+  } catch {} finally {
+    loadingAreas.value = false
+  }
+}
+
+const handleQuickAction = (actionId: string) => {
+  if (actionId === 'new-reservation') {
+    resetForm()
+    router.push('/resident/reservations/new')
+  }
+}
+
 const handleLogout = async () => {
   try { await http.post('/auth/logout') } catch {}
   authService.logout()
   router.push('/')
 }
 
+onMounted(() => {
+  fetchAreas()
+})
 </script>
+
+<style scoped>
+.material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+</style>

--- a/apps/web/src/modules/resident/pages/ResidentDashboard.vue
+++ b/apps/web/src/modules/resident/pages/ResidentDashboard.vue
@@ -154,6 +154,33 @@ async function fetchCommonAreas() {
   }
 }
 
+async function fetchReservations() {
+  try {
+    const res = await http.get('/reservations', { params: { status: 'APPROVED', limit: 5 } })
+    const data = (res.data as any).data as any
+    reservations.value = (data.reservations || []).map((r: any) => ({
+      id: r.id,
+      title: r.commonArea?.name || 'Área Comum',
+      schedule: `${formatDate(r.startTime)} • ${formatTime(r.startTime)} - ${formatTime(r.endTime)}`,
+      resident: r.resident?.user?.name || '',
+      status: r.status === 'APPROVED' ? 'Confirmado' : r.status === 'PENDING' ? 'Pendente' : 'Cancelado',
+      icon: r.commonArea?.icon || 'home_work',
+    }))
+  } catch {
+    reservations.value = []
+  }
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'long' })
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+}
+
 const handleLogout = async () => {
   try {
     await http.post('/auth/logout')
@@ -172,5 +199,6 @@ const handleQuickAction = (actionId: string) => {
 
 onMounted(() => {
   fetchCommonAreas()
+  fetchReservations()
 })
 </script>

--- a/apps/web/src/modules/shared/components/SideNavBar.vue
+++ b/apps/web/src/modules/shared/components/SideNavBar.vue
@@ -108,7 +108,10 @@ const roleLabel = computed(() => roleConfig[props.role]?.subtitle || 'Menu')
 const ctaLabel = computed(() => roleConfig[props.role]?.ctaLabel || '')
 const ctaIcon = computed(() => roleConfig[props.role]?.ctaIcon || 'add')
 const dashboardPath = computed(() => props.role === 'ADMIN' ? '/condominium/dashboard' : '/resident/dashboard')
-const ctaActionId = computed(() => props.role === 'ADMIN' ? 'admin-cta' : 'resident-cta')
+const ctaActionId = computed(() => {
+  if (props.role === 'RESIDENT') return 'new-reservation'
+  return `${props.role.toLowerCase()}-cta`
+})
 
 const isActiveRoute = (path: string) => route.path === path || route.path.startsWith(path + '/')
 


### PR DESCRIPTION
…leto

US06 - Consultar disponibilidade
- GET /common-areas/:id/availability com validação de dias/horários operacionais e conflitos
- GET /common-areas/:id/busy-days para calendário mensal colorido
- AvailabilityPage com calendário e timeline visual
- Inclusão na rota admin (/condominium/availability)
- Horários passados filtrados como indisponíveis

US07 - Realizar reserva
- POST /reservations com validação completa (área, tenant, manutenção, dias/horários operacionais, start < end, duração mínima 2h, morador existe e canBook, conflitos)
- Status PENDING se requiresApproval, APPROVED caso contrário
- NewReservationPage com calendário + timeline + seletores de horário com validação visual
- Confirmação via modal
- Query params para navegação entre páginas

US08 - Cancelar reserva
- PATCH /reservations/:id/cancel com trilha de auditoria (canceledById, canceledAt)
- Botão cancelar com confirmação em MyReservationsPage e ReservationsPage (admin)

US09 - Listar minhas reservas
- GET /reservations com paginação, filtro por status, escopo por papel
- Filtros: Próximas, Anteriores, Pendentes, Confirmadas, Canceladas
- Expand/collapse com detalhes e timeline do dia

US10 - Listar todas as reservas (admin)
- GET /reservations para ADMIN retorna todas do condomínio
- ReservationsPage com tabela, filtros, expand/collapse, cancelamento

Correções:
- Duplicata de @Post() no controller (POST caía no findAll)
- Sidebar CTA navegando para /resident/reservations/new
- Dashboard contando reservas do backend
- Suporte a múltiplos status (comma-separated) no filtro

Testes: 217 passando (de 213)