### PR TITLE
fix: corrige path duplicado no deploy Vercel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,6 @@ jobs:
     name: Deploy API (apps/api)
     runs-on: ubuntu-latest
     environment: Production
-    defaults:
-      run:
-        working-directory: apps/api
 
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -30,9 +27,6 @@ jobs:
     name: Deploy Web (apps/web)
     runs-on: ubuntu-latest
     environment: Production
-    defaults:
-      run:
-        working-directory: apps/web
 
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,8 +1,7 @@
 {
   "version": 2,
-  "installCommand": "npm install",
-  "buildCommand": "npx prisma generate && npx --package @nestjs/cli nest build",
+  "buildCommand": "prisma generate && npm run build",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/api/index.ts" }
+    { "source": "/(.*)", "destination": "/api/index" }
   ]
 }


### PR DESCRIPTION
## O que foi corrigido

### Problema
O deploy automático quebrava com:
```
Error: The provided path ".../apps/api/apps/api" does not exist.
```

**Causa raiz:** O path `apps/api` era duplicado porque:
1. O projeto Vercel **API** tem Root Directory = `apps/api`
2. O workflow `deploy.yml` usava `defaults.run.working-directory: apps/api`
3. Vercel combinava ambos → `apps/api/apps/api` (path inexistente)

### Correções
1. **`.github/workflows/deploy.yml`**: Removeu `defaults.run.working-directory` de ambos os jobs
2. **`apps/api/vercel.json`**: Removeu `installCommand`, simplificou `buildCommand` para `prisma generate && npm run build`, corrigiu rewrite destination

### ⚠️ Necessário verificar
- **DATABASE_URL** precisa estar configurada nas env vars do Vercel (projeto api)
- **JWT_SECRET** e **CORS_ORIGIN** também precisam estar configurados