### PR TITLE
fix: corrigir outputDirectory no vercel.json do web

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "buildCommand": "npm run build",
 
-  "outputDirectory": "apps/web/dist",
+  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Problema

O `outputDirectory` em `apps/web/vercel.json` estava configurado como `"apps/web/dist"`, mas o workflow do GitHub Actions executa `vercel deploy` de dentro de `apps/web/` (via `defaults.run.working-directory: apps/web`).

Isso fazia o Vercel resolver o caminho como `apps/web/apps/web/dist` — que não existe — resultando no erro:

> No Output Directory named "dist" found after the Build completed

## Fix

Mudar `outputDirectory` de `"apps/web/dist"` para `"dist"`, já que o Vercel considera `apps/web/` como raiz do projeto.