### PR TITLE
fix: ajustar deploy Vercel da API e web, corrigir logger para serverless

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,4 +42,4 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: 🚀 Deploy Web no Vercel
-        run: vercel deploy --prod --yes --token "${{ secrets.VERCEL_TOKEN }}"
+        run: vercel deploy --prod --yes --project "${{ secrets.VERCEL_WEB_PROJECT_ID }}" --build-env VITE_API_URL="https://api-two-ruddy-44.vercel.app/api/v1" --token "${{ secrets.VERCEL_TOKEN }}"

--- a/apps/api/api/index.ts
+++ b/apps/api/api/index.ts
@@ -140,7 +140,17 @@ async function bootstrap() {
 
 export default async function handler(req: any, res: any) {
   if (!cachedApp) {
-    cachedApp = await bootstrap();
+    try {
+      cachedApp = await bootstrap();
+    } catch (err: any) {
+      console.error('[Vercel] Bootstrap failed:', err);
+      res.status(500).json({
+        statusCode: 500,
+        message: 'Internal server error',
+        error: process.env.VERCEL_ENV === 'development' ? err.message : undefined,
+      });
+      return;
+    }
   }
   cachedApp(req, res);
 }

--- a/apps/api/src/logger/logger.middleware.ts
+++ b/apps/api/src/logger/logger.middleware.ts
@@ -6,12 +6,19 @@ import * as path from 'path';
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
   private logger = new Logger('HTTP');
-  private logDir = path.join(process.cwd(), 'logs');
-  private logFilePath = path.join(this.logDir, 'app.log');
+  private logDir: string;
+  private logFilePath: string;
+  private useFileLogging = true;
 
   constructor() {
-    if (!fs.existsSync(this.logDir)) {
-      fs.mkdirSync(this.logDir, { recursive: true });
+    this.logDir = path.join(process.env.VERCEL ? '/tmp' : process.cwd(), 'logs');
+    this.logFilePath = path.join(this.logDir, 'app.log');
+    try {
+      if (!fs.existsSync(this.logDir)) {
+        fs.mkdirSync(this.logDir, { recursive: true });
+      }
+    } catch {
+      this.useFileLogging = false;
     }
   }
 
@@ -30,7 +37,9 @@ export class LoggerMiddleware implements NestMiddleware {
 
       this.logger.log(logMessage);
 
-      this.writeToFile(logMessage);
+      if (this.useFileLogging) {
+        this.writeToFile(logMessage);
+      }
     });
 
     next();
@@ -38,11 +47,10 @@ export class LoggerMiddleware implements NestMiddleware {
 
   private writeToFile(message: string): void {
     const logLine = message + '\n';
-
-    fs.appendFile(this.logFilePath, logLine, (err) => {
-      if (err) {
-        console.error('[Logger] Erro ao escrever no log:', err);
-      }
-    });
+    try {
+      fs.appendFileSync(this.logFilePath, logLine);
+    } catch (err) {
+      console.error('[Logger] Erro ao escrever no log:', err);
+    }
   }
 }

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -2,6 +2,11 @@
   "version": 2,
   "installCommand": "npm install",
   "buildCommand": "npx prisma generate && npx --package @nestjs/cli nest build",
+  "functions": {
+    "api/index.ts": {
+      "maxDuration": 30
+    }
+  },
   "rewrites": [
     { "source": "/(.*)", "destination": "/api/index.ts" }
   ]


### PR DESCRIPTION
## O que foi feito

### Problemas corrigidos na API (Vercel)

1. **LoggerMiddleware quebrava no Vercel** (`apps/api/src/logger/logger.middleware.ts`)
   - Antes: tentava criar pasta `logs/` com `fs.mkdirSync` no filesystem readonly do Vercel → crash
   - Agora: detecta `VERCEL=true` e usa `/tmp`; trata erro de escrita silenciosamente

2. **Serverless handler sem error handling** (`apps/api/api/index.ts`)
   - Antes: `bootstrap()` sem try/catch → qualquer erro (DB, módulo) causava `FUNCTION_INVOCATION_FAILED`
   - Agora: captura erros e retorna JSON 500 com a mensagem

3. **`vercel.json` sem config de função** (`apps/api/vercel.json`)
   - Adicionado `functions.api/index.ts` com `maxDuration: 30`

### Ajuste no CI/CD (`.github/workflows/deploy.yml`)

> **Nota:** O deploy.yml precisa ser atualizado manualmente localmente (o push via API falhou para esse arquivo). A alteração é adicionar `--project` e `--build-env VITE_API_URL` no step de deploy web.

## Testes realizados

- `POST /api/v1/auth/register` → ✅ 201 + JWT
- `POST /api/v1/auth/login` → ✅ 200 + JWT
- `GET /api/v1/docs` → ✅ Swagger UI
- Banco Neon PostgreSQL → ✅ conectado
