### PR TITLE
fix: corrigir leitura do token JWT do localStorage (JSON.parse)

### DIFF
--- a/apps/web/src/api/http.ts
+++ b/apps/web/src/api/http.ts
@@ -10,7 +10,8 @@ const { start, finish } = useLoading();
 
 http.interceptors.request.use((config) => {
     start();
-    const token = localStorage.getItem("auth_token");
+    const raw = localStorage.getItem("auth_token");
+    const token = raw ? JSON.parse(raw) : null;
     if (token) {
         config.headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
## Problema

Após o registro/login, o dashboard fazia várias requisições para endpoints protegidos e todas retornavam **401 Unauthorized**, redirecionando o usuário de volta ao login.

## Causa

O `authService.ts` armazena o token no localStorage com `JSON.stringify()`, que adiciona aspas duplas ao redor do valor: `"eyJ..."`. O `http.ts` lia com `localStorage.getItem()` direto, retornando o token **com aspas**: `"eyJ..."`.

O header Authorization ficava `Bearer "eyJ..."` (aspas inclusas), tornando o JWT inválido.

## Correção

`apps/web/src/api/http.ts`: usar `JSON.parse()` ao ler o token do localStorage, igual ao `authService.getToken()` faz.

## Testes

- `POST /api/v1/auth/register` → ✅ 201 + JWT
- `GET /api/v1/residents` com token → ✅ 200
- `GET /api/v1/common-areas` com token → ✅ 200
- `GET /api/v1/announcements` com token → ✅ 200