### PR TITLE
feat: adicionar timeout e retry config na API (Prisma, NestJS, Vercel)

### DIFF
--- a/apps/api/api/index.ts
+++ b/apps/api/api/index.ts
@@ -15,6 +15,16 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.use(cookieParser());
+  app.use((_req: any, res: any, next: any) => {
+    res.setTimeout(25000, () => {
+      res.status(408).json({
+        success: false,
+        statusCode: 408,
+        message: 'O servidor demorou muito para responder. Tente novamente.',
+      });
+    });
+    next();
+  });
   app.setGlobalPrefix('api/v1');
 
   app.useGlobalPipes(

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,6 +19,16 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
+  app.use((_req: any, res: any, next: any) => {
+    res.setTimeout(25000, () => {
+      res.status(408).json({
+        success: false,
+        statusCode: 408,
+        message: 'O servidor demorou muito para responder. Tente novamente.',
+      });
+    });
+    next();
+  });
   app.setGlobalPrefix('api/v1');
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -9,13 +9,27 @@ export class PrismaService
   implements OnModuleInit, OnModuleDestroy
 {
   constructor() {
-    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    const pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      connectionTimeoutMillis: 15000,
+      idleTimeoutMillis: 30000,
+      max: 5,
+    });
     const adapter = new PrismaPg(pool);
-    super({ adapter });
+    super({
+      adapter,
+      log: ['warn', 'error'],
+    });
   }
 
   async onModuleInit() {
-    await this.$connect();
+    try {
+      await this.$connect();
+      await this.$executeRawUnsafe('SET statement_timeout = 30000');
+    } catch (error) {
+      console.error('Prisma connection failed:', error);
+      throw error;
+    }
   }
 
   async onModuleDestroy() {

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -4,5 +4,10 @@
   "buildCommand": "npx prisma generate && npx --package @nestjs/cli nest build",
   "rewrites": [
     { "source": "/(.*)", "destination": "/api/index.ts" }
-  ]
+  ],
+  "functions": {
+    "api/index.ts": {
+      "maxDuration": 30
+    }
+  }
 }


### PR DESCRIPTION
### Problema
A API NestJS no Vercel não tinha timeout para conexões Prisma nem para requisições HTTP, causando 404 quando o servidor demorava para responder (cold start, rede lenta).

### Solução
1. **`prisma.service.ts`**: Pool config com `connectionTimeoutMillis: 15000`, `idleTimeoutMillis: 30000`, `max: 5`, e `statement_timeout = 30000` no PostgreSQL.
2. **`main.ts` e `api/index.ts`**: Middleware de timeout de 25s que retorna 408 com mensagem amigável.
3. **`vercel.json` (API)**: `maxDuration: 30` para dar mais tempo ao serverless function no cold start.