### PR TITLE
fix: alinhar workflow deploy web com o da develop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: 🚀 Deploy API no Vercel
-        run: vercel deploy --prod --yes --project "${{ secrets.VERCEL_API_PROJECT_ID }}" --token "${{ secrets.VERCEL_TOKEN }}"
+        run: vercel deploy --prod --yes --token "${{ secrets.VERCEL_TOKEN }}"
 
   deploy-web:
     name: Deploy Web (apps/web)
@@ -42,4 +42,4 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: 🚀 Deploy Web no Vercel
-        run: vercel deploy --prod --yes --project "${{ secrets.VERCEL_WEB_PROJECT_ID }}" --build-env VITE_API_URL="https://api-two-ruddy-44.vercel.app/api/v1" --token "${{ secrets.VERCEL_TOKEN }}"
+        run: vercel deploy --prod --yes --token "${{ secrets.VERCEL_TOKEN }}"


### PR DESCRIPTION
### Problema
Workflow da main passava `--project` e `--build-env` no `vercel deploy`, o que fazia o Vercel ignorar o `vercel.json` local de `apps/web/` e procurava o output em `dist` em vez de `apps/web/dist`.

### Solução
Removi `--project` (já definido via env var `VERCEL_PROJECT_ID`) e `--build-env` (configurado como env var no projeto Vercel). O workflow agora fica idêntico ao da develop, que funciona.

### Diff
- `--project "${{ secrets.VERCEL_WEB_PROJECT_ID }}" --build-env VITE_API_URL=...`
+ `sem flags, usa env vars do ambiente do job`