### PR TITLE
fix: outputDirectory dist em vez de apps/web/dist

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "buildCommand": "npm run build",
 
-  "outputDirectory": "apps/web/dist",
+  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
### Problema
O `vercel.json` do web tinha `outputDirectory: apps/web/dist`, mas o deploy roda dentro de `apps/web/` (pelo `working-directory` do GitHub Action). Isso fazia Vercel procurar o output em `apps/web/apps/web/dist`.

### Solução
Mudei para `outputDirectory: dist` (igual ao develop), que é relativo a `apps/web/`.

### Diff
- `apps/web/vercel.json`: `"outputDirectory": "apps/web/dist"` → `"outputDirectory": "dist"`
- Projeto Vercel: `outputDirectory` atualizado via API para `dist`