### PR TITLE
fix: deploy com --prebuilt em vez de build remoto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,20 +20,23 @@ jobs:
       - name: 📦 Instalar Vercel CLI
         run: npm install --global vercel@latest
 
+      - name: 🔨 Build API
+        run: npm run build
+        working-directory: apps/api
+
       - name: 🚀 Deploy API no Vercel
-        run: vercel deploy --prod --yes --token "${{ secrets.VERCEL_TOKEN }}"
+        run: vercel deploy --prod --prebuilt --yes --token "${{ secrets.VERCEL_TOKEN }}"
+        working-directory: apps/api
 
   deploy-web:
     name: Deploy Web (apps/web)
     runs-on: ubuntu-latest
     environment: Production
-    defaults:
-      run:
-        working-directory: apps/web
 
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
+      VITE_API_URL: https://api-two-ruddy-44.vercel.app/api/v1
 
     steps:
       - uses: actions/checkout@v4
@@ -41,5 +44,13 @@ jobs:
       - name: 📦 Instalar Vercel CLI
         run: npm install --global vercel@latest
 
+      - name: 🔧 Instalar dependencias
+        run: npm ci
+
+      - name: 🔨 Build Web
+        run: npm run build
+        working-directory: apps/web
+
       - name: 🚀 Deploy Web no Vercel
-        run: vercel deploy --prod --yes --token "${{ secrets.VERCEL_TOKEN }}"
+        run: vercel deploy --prod --prebuilt --yes --token "${{ secrets.VERCEL_TOKEN }}"
+        working-directory: apps/web


### PR DESCRIPTION
### Problema
O `vercel deploy` sem `--prebuilt` faz o build no servidor remoto da Vercel, mas o config do `vercel.json` nao estava sendo aplicado corretamente, resultando em "No Output Directory named dist found".

### Solucao
- Build local no GitHub Action (`npm run build`)
- Deploy com `--prebuilt` (apenas upload do diretorio ja compilado)
- VITE_API_URL definido como env var do job
- Remove dependencia do build remoto da Vercel