### PR TITLE
fix: redirect para /condominium/dashboard apos registro

### DIFF
--- a/apps/web/src/modules/auth/pages/RegisterPage.vue
+++ b/apps/web/src/modules/auth/pages/RegisterPage.vue
@@ -72,7 +72,7 @@ const handleRegister = async (formData: RegisterTenantDTO) => {
   try {
     const response = await authService.registerTenant(formData)
     toastSuccess(response.message)
-    router.push('/dashboard')
+    router.push('/condominium/dashboard')
   } catch (error: any) {
     if (error.retryMessage) {
       errorMsg.value = error.retryMessage


### PR DESCRIPTION
RegisterPage.vue redirecionava para `/dashboard` (rota inexistente, 404). Agora redireciona para `/condominium/dashboard`.