### PR TITLE
Fix register timeout: login fallback + increase backend timeout

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
   app.use((_req: any, res: any, next: any) => {
-    res.setTimeout(25000, () => {
+    res.setTimeout(60000, () => {
       res.status(408).json({
         success: false,
         statusCode: 408,

--- a/apps/web/src/modules/auth/pages/RegisterPage.vue
+++ b/apps/web/src/modules/auth/pages/RegisterPage.vue
@@ -74,6 +74,23 @@ const handleRegister = async (formData: RegisterTenantDTO) => {
     toastSuccess(response.message)
     router.push('/condominium/dashboard')
   } catch (error: any) {
+    const isTimeout = error.code === 'ECONNABORTED' || error.retryMessage
+    if (isTimeout) {
+      try {
+        const loginResponse = await authService.login({
+          email: formData.adminEmail,
+          password: formData.adminPassword,
+        })
+        toastSuccess('Conta criada com sucesso!')
+        const redirectPath = loginResponse.user.role === 'ADMIN'
+          ? '/condominium/dashboard'
+          : '/resident/dashboard'
+        router.push(redirectPath)
+        return
+      } catch {
+        // login falhou também — conta não foi criada
+      }
+    }
     if (error.retryMessage) {
       errorMsg.value = error.retryMessage
     } else if (error.code === 'ECONNABORTED') {


### PR DESCRIPTION
## Problema
No Neon (PostgreSQL serverless), o cadastro de usuário demora >25s no cold start. O timeout do backend (25s) disparava antes da transação completar, mas o usuário já havia sido criado. O frontend exibia erro mesmo com a conta criada.

## Solução
- **Frontend (`RegisterPage.vue`)**: quando o register falha por timeout, tenta login automaticamente com as mesmas credenciais. Se logar → conta foi criada → redireciona pro dashboard.
- **Backend (`main.ts`)**: timeout global aumentado de 25s para 60s para dar mais folga ao Neon em cold start.