### PR TITLE
Feat: Agents and Unit/Block (#69)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: 🚀 Deploy API no Vercel
-        run: vercel deploy --prod --yes --token "${{ secrets.VERCEL_TOKEN }}"
+        run: vercel deploy --prod --yes --project "${{ secrets.VERCEL_API_PROJECT_ID }}" --token "${{ secrets.VERCEL_TOKEN }}"
 
   deploy-web:
     name: Deploy Web (apps/web)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,199 @@
+# Reserva Aí! - Contexto do Projeto
+
+## Propósito
+Plataforma web para gestão de reservas de áreas comuns em condomínios. Moradores reservam espaços como salão de festas, churrasqueira, piscina; administradores gerenciam condomínio, moradores, áreas e aprovam/rejeitam reservas.
+
+## Tech Stack
+- **Monorepo:** NPM Workspaces (`apps/*`)
+- **Backend:** NestJS 11 + Prisma ORM 7 + PostgreSQL (Neon)
+- **Frontend:** Vue 3 (Composition API, `<script setup>`) + Vite
+- **Auth:** JWT (1d expiry) + HttpOnly cookie + Bearer header
+- **Validação:** class-validator + class-transformer + ValidationPipe (whitelist)
+- **Documentação:** @nestjs/swagger em `/api/v1/docs`
+
+## Metodologia: TDD (Test-Driven Development)
+**Sempre construir código para passar no teste primeiro.** O fluxo de desenvolvimento segue TDD (Red-Green-Refactor):
+
+1. **Escreva o teste** (Red) - o teste falha pois a funcionalidade não existe
+2. **Implemente o código mínimo** (Green) - código apenas para passar no teste
+3. **Refatore** (Refactor) - melhore sem quebrar o teste
+
+Isso se aplica tanto ao **backend** (`npm run dev:api:test`) quanto ao **frontend** (`npm run dev:web:test`).
+
+Workflows de desenvolvimento disponíveis em `.agents/workflows/`:
+- `tdd-worker.md` - Pipeline TDD automatizado (4 fases: Data → Backend → UI → Frontend)
+- `tdd-worker-didatico.md` - Versão didática com explicações passo a passo
+- `sdd-architect.md` - Spec-Driven Development (gerar critérios de aceitação antes do código)
+
+Skills especializadas disponíveis em `.agents/skills/`: nestjs-expert, prisma-expert, postgresql, vue-best-practices, vue-testing-best-practices, vue-router-best-practices, vue-pinia-best-practices, vue-debug-guides, neon-postgres, create-adaptable-composable, vue-jsx-best-practices, vue-options-api-best-practices.
+
+## Estrutura
+
+### `apps/api` - Backend NestJS
+```
+src/
+├── auth/          # Login, register, JWT guards, cookie utils, validators
+├── common/        # Filters (DomainException, HttpException), interceptors, exceptions
+├── condominiums/  # CRUD do condomínio do admin logado
+├── residents/     # CRUD de moradores (admin only), validators
+├── common-areas/  # CRUD áreas comuns, availability, busy-days, closed-dates, validators
+├── reservations/  # CRUD reservas, approve, reject, cancel
+├── announcements/ # CRUD comunicados
+├── prisma/        # PrismaService (singleton, Pool pg max 5, statement_timeout 30s)
+├── logger/        # LoggerMiddleware (console + log file)
+├── types/         # Tipos globais (Role enum, Express Request com user)
+└── main.ts        # Bootstrap, Swagger, CORS, ValidationPipe global, timeout 25s
+```
+
+**Módulos:** auth, users, residents, condominiums, common-areas, reservations, announcements
+**Serviços principais:** PrismaService, AuthService, UsersService, ResidentsService, CondominiumsService, CommonAreasService, ReservationsService, ReservationApprovalsService, AnnouncementsService
+**Guards:** JwtAuthGuard (cookie `access_token` primeiro, depois Bearer header), RolesGuard (ADMIN/RESIDENT/SUPER_ADMIN)
+**Context pattern:** `ServiceContext { role, condominiumId, userId }` passado manualmente do controller ao service
+**Paginação:** Todos os endpoints de lista suportam `?page=&limit=` (default page=1, limit=10, announcements limit=20)
+**Validação extra:** Validators dedicados (RegisterTenantValidator, LoginValidator, CreateResidentValidator, CreateCommonAreaValidator) complementam os DTOs
+
+### `apps/web` - Frontend Vue 3
+```
+src/
+├── api/           # Axios instance (http.ts) com interceptors (token, retry com backoff, 401 redirect)
+├── modules/
+│   ├── auth/      # Login, register, auth service (localStorage), rotas
+│   ├── admin/     # Dashboard admin, CRUD áreas, moradores, comunicados
+│   ├── resident/  # Dashboard morador, reservas
+│   ├── landing/   # Landing page
+│   └── shared/    # Composables (useLoading, useToast, useSidebar, useUserRole, useApiError), NotFoundPage
+├── router/        # Vue Router (guards por auth token e role, XSS protection no path)
+├── store/         # Vazio - estado via localStorage + composables singleton
+└── utils/         # Helpers
+```
+
+**Estado:** localStorage (`auth_token`, `auth_user`, `auth_condo`) lido pelo `AuthService` singleton. Composables com `ref` module-level para loading/toast/sidebar. Sem Pinia/Vuex.
+**HTTP interceptor:** Retry automático (2 tentativas, exponential backoff 1s-4s) para status retryable (0, 408, 429, 500, 502, 503, 504). Redireciona para `/login` em 401.
+
+## Modelo de Dados (Prisma)
+- **User** (id, name, email, passwordHash, provider[LOCAL,GOOGLE], role[SUPER_ADMIN,ADMIN,RESIDENT], condominiumId, isActive)
+- **Condominium** (id, name, address, timezone)
+- **Block** (id, name, condominiumId) - GET/POST/PATCH/DELETE /blocks
+- **Unit** (id, number, blockId) - GET/POST/PATCH/DELETE /units, filtro por ?blockId=
+- **Resident** (id, userId[unique], unitId, document, phone, canBook)
+- **CommonArea** (id, name, description, capacity, openTime, closeTime, operatingDays[JSON], closedDates[JSON], requiresApproval, icon, isUnderMaintenance[default false], condominiumId)
+- **Reservation** (id, residentId, commonAreaId, startTime, endTime, status[PENDING,APPROVED,REJECTED,CANCELED], notes, canceledById, canceledAt)
+- **ReservationApproval** (id, reservationId, approvedBy, approvedAt, status[APPROVED,REJECTED], comment)
+- **Announcement** (id, title, content, condominiumId, authorId, isActive[default true])
+
+## Regras de Negócio (RNs)
+- RN01: Isolamento multi-tenant por `condominiumId` em todas as queries. SUPER_ADMIN não tem condomínio vinculado - acesso negado a recursos tenant-scoped.
+- RN01.1: Moradores não têm cadastro público - criados apenas por admin (POST /residents gera JWT + senha temporária para o morador).
+- RN02: Criação de condomínio + admin raiz em transação única (`POST /auth/register`)
+- RN03: Sem conflito de horário na mesma área; duração mínima 2h (120 min)
+- RN03.1: Cada área tem horário de funcionamento, dias operacionais e capacidade validados
+- RN03.2: Duração mínima de 2 horas (startTime < endTime, diff >= 120 min)
+- RN03.3: `requiresApproval=true` → status `PENDING`; senão `APPROVED`
+- RN03.4: `closedDates` bloqueiam reservas na data; busy-days mescla reservas + closedDates
+- RN03.5: `isUnderMaintenance=true` bloqueia todas as reservas da área
+- RN04: Cancelamento é soft delete (status CANCELED, registra canceledById, canceledAt). Autor da reserva ou admin podem cancelar.
+- RN05: Aprovação/rejeição exclusiva de admin do mesmo condomínio, registrado em `reservation_approvals` (via `$transaction`).
+- RN06: Admin pode criar reserva em nome de morador (`residentId` opcional no CreateReservationDto).
+- RN07: Exclusão de área comum bloqueada se houver reservas PENDING ou APPROVED ativas.
+- RN08: Comunicados têm soft-delete (isActive=false), não exclusão física.
+
+## Endpoints da API (`/api/v1`)
+### Auth
+- `POST /auth/register` - Cria condomínio + admin (RegisterTenantDTO)
+- `POST /auth/login` - Login (retorna JWT + user + condominium)
+- `POST /auth/logout`
+- `PATCH /auth/me` - Atualizar perfil
+- `POST /auth/change-password`
+
+### Condominiums
+- `GET /condominiums` - Dados do condomínio do admin logado
+- `PATCH /condominiums`
+
+### Residents
+- `POST /residents` - Admin cria morador (retorna JWT + temp password)
+- `GET /residents` - Listar (query: page, limit)
+- `GET /residents/:id`
+- `PATCH /residents/:id/permissions` - Alterar `canBook`
+
+### Common Areas
+- `POST /common-areas` - Admin
+- `GET /common-areas` (query: page, limit)
+- `GET /common-areas/:id`
+- `GET /common-areas/:id/availability?date=YYYY-MM-DD&startTime=&endTime=`
+- `GET /common-areas/:id/busy-days?year=&month=`
+- `PATCH /common-areas/:id` - Admin
+- `DELETE /common-areas/:id` - Admin (bloqueado se há reservas ativas)
+- `POST /common-areas/:id/closed-dates` - Admin
+- `DELETE /common-areas/:id/closed-dates` - Admin
+
+### Reservations
+- `POST /reservations` (body: commonAreaId, date, startTime, endTime, notes?, residentId? [admin only])
+- `GET /reservations?status=&from=&to=&page=&limit=` (RESIDENT vê próprias; ADMIN vê todas do condomínio)
+- `PATCH /reservations/:id/cancel`
+- `PATCH /reservations/:id/approve` (Admin, via $transaction)
+- `PATCH /reservations/:id/reject` (Admin, via $transaction)
+
+### Blocks
+- `POST /blocks` - Admin cria bloco
+- `GET /blocks` (query: page, limit)
+- `GET /blocks/:id`
+- `PATCH /blocks/:id` - Admin
+- `DELETE /blocks/:id` - Admin (bloqueado se há unidades vinculadas)
+
+### Units
+- `POST /units` - Admin cria unidade (body: number, blockId)
+- `GET /units` (query: page, limit, blockId?)
+- `GET /units/:id`
+- `PATCH /units/:id` - Admin
+- `DELETE /units/:id` - Admin (bloqueado se há moradores vinculados)
+
+### Announcements
+- `POST /announcements` (Admin)
+- `GET /announcements` (query: page, limit)
+- `DELETE /announcements/:id` (Admin, soft-delete isActive=false)
+
+## Credenciais de Teste (Seed)
+
+Após rodar `npm run dev:prisma:seed`:
+
+| Papel   | E-mail              | Senha         |
+|---------|---------------------|---------------|
+| Admin   | admin@reservai.com  | Admin@123     |
+| Morador | morador@reservai.com| Resident@123  |
+
+O seed cria Condomínio Vila Verde, Bloco A/Ap 101, 8 áreas comuns, admin e morador.
+
+## Comandos
+```bash
+npm run dev:api          # Iniciar backend
+npm run dev:web          # Iniciar frontend
+npm run dev:prisma       # Gerar Prisma client + deploy migrations
+npm run dev:prisma:seed  # Idem + seed
+npm run dev:prisma:studio # Prisma Studio (porta 5555)
+npm run dev:api:test     # Testes unitários backend (~20 spec files)
+npm run dev:api:test:e2e # Testes E2E backend (auth flow)
+npm run dev:api:test:cover # Testes com cobertura
+npm run dev:web:test     # Testes frontend
+```
+
+## Padrões de Código
+- **NestJS:** modular (`@Module`), controllers injetam services, guards aplicados por rota. TransformInterceptor aplicado por controller (não global). DomainExceptionFilter + HttpExceptionFilter globais.
+- **Vue 3:** Composition API com `<script setup>`, módulos por domínio, Axios via `http.ts`
+- **Auth:** token em localStorage no frontend; JWT em cookie + header no backend (cookie tem prioridade)
+- **Erros (sucesso):** `TransformInterceptor` → `{ success: true, timestamp, data }`
+- **Erros (DomainException):** `{ statusCode, code, message, details, timestamp, path }` (sem `success`)
+- **Erros (HttpException):** `{ success: false, statusCode, path, message }`
+- **Erros (Validation):** `{ statusCode, code: 'VALIDATION_FAILED', message, details[] }`
+- **Prisma:** `PrismaPg` adapter com `Pool` (max 5), `statement_timeout = 30000`
+- **Timeout:** Middleware 25s → HTTP 408
+- **DomainExceptions:** 19 classes de exceção de domínio em 4 arquivos (resident, condominium, common-area, reservation)
+- **Testes:** 20 unit spec files + 2 e2e spec files. Setup global mock para bcrypt.hash.
+
+## Observações Técnicas
+- Anúncios sem endpoint de edição (apenas criar e deletar)
+- `Provider.GOOGLE` existe no schema mas não há implementação de OAuth Google
+- `GET /units?blockId=` filtra unidades por bloco
+- Swagger JSON exportado para `swagger.json` na inicialização
+- `POST /residents` gera senha temporária automaticamente se não fornecida
+- Aprovação/rejeição de reserva usa `$transaction` (atualiza status + cria reservation_approval atomicamente)
+- Delete de common-area verifica reservas com status PENDING ou APPROVED

--- a/README.md
+++ b/README.md
@@ -26,40 +26,112 @@ Toda a especificação do sistema está versionada na pasta `/docs`:
 
 ## 🛠 3. Stack Tecnológica
 
-- **Arquitetura:** Monorepo (Back, Front e Extensão no mesmo repositório).
-- **Backend (API):** NestJS, TypeScript, JWT, Google OAuth.
-- **Banco de Dados:** PostgreSQL (Nuvem) gerenciado via Prisma ORM.
+- **Arquitetura:** Monorepo (Back, Front no mesmo repositório).
+- **Backend (API):** NestJS, TypeScript, JWT.
+- **Banco de Dados:** PostgreSQL gerenciado via Prisma ORM.
 - **Frontend (Web):** Vue.js + TailwindCSS.
 - **Integração:** Consumo de API Externa (Brasil API para feriados nacionais).
 
 ## 🚀 4. Quick Start (Como Executar)
 
-**1. Clone o repositório:**
+### Pré-requisitos
 
-    git clone https://github.com/lucasgfaj/reserva-ai.git
-    cd reserva-ai
+- **Node.js** 20+
+- **PostgreSQL** (local com Docker ou Neon/Supabase na nuvem)
+- **Docker** (opcional, para PostgreSQL local)
 
-**2. Configuração Inicial e Variáveis de Ambiente:**
-Não esqueça de copiar o arquivo `.env.example` para `.env` dentro da pasta `apps/api` e configurar a `DATABASE_URL` do seu PostgreSQL. Em seguida, instale as dependências executando na raiz:
+### 4.1. Clone e instale dependências
 
-    npm install
+```bash
+git clone https://github.com/lucasgfaj/reserva-ai.git
+cd reserva-ai
+npm install
+```
 
-**3. Banco de Dados:**
-Para gerar o Prisma Client e atualizar o banco de dados:
+### 4.2. Configure o Banco de Dados
 
-    npm run dev:prisma
+**Opção A — PostgreSQL local com Docker (recomendado):**
 
-**4. Iniciar a Aplicação:**
-A partir da raiz do monorepo, inicie os serviços (abra terminais separados):
+```bash
+docker run --name reserva-pg -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=reserva_ai_db -p 5432:5432 -d postgres:16-alpine
+```
 
-    # Terminal 1 - Iniciar a API NestJS
-    npm run dev:api
+**Opção B — PostgreSQL na nuvem (Neon, Supabase, Railway):**
 
-    # Terminal 2 - Iniciar o Frontend
-    npm run dev:web
+Crie um banco gratuito em [neon.tech](https://neon.tech) ou [supabase.com](https://supabase.com) e copie a `DATABASE_URL`.
 
-    # Terminal 3 - Prisma Studio (Visão do Banco - Opcional)
-    npm run dev:prisma:studio
+### 4.3. Variáveis de Ambiente
+
+```bash
+cp apps/api/.env.example apps/api/.env
+```
+
+Edite `apps/api/.env` se necessário. O padrão já funciona com o Docker local.
+
+### 4.4. Rodar migrations + seed
+
+```bash
+npm run dev:prisma:seed
+```
+
+Esse comando gera o Prisma Client, aplica as migrations e popula o banco com dados de demonstração.
+
+### 4.5. Iniciar a aplicação
+
+Abra **dois terminais**:
+
+```bash
+# Terminal 1 - Backend (porta 3000)
+npm run dev:api
+
+# Terminal 2 - Frontend (porta 5173)
+npm run dev:web
+```
+
+Acesse: http://localhost:5173
+Documentação Swagger: http://localhost:3000/api/v1/docs
+Prisma Studio (opcional): `npm run dev:prisma:studio`
+
+## 🔐 Credenciais de Teste (Seed)
+
+Após rodar o seed, use estas credenciais para testar:
+
+| Papel   | E-mail              | Senha         |
+|---------|---------------------|---------------|
+| Admin   | admin@reservai.com  | Admin@123     |
+| Morador | morador@reservai.com| Resident@123  |
+
+### O que o seed cria
+
+- **Condomínio:** Condomínio Vila Verde
+- **Bloco/Unidade:** Bloco A, Ap 101
+- **Admin:** admin@reservai.com (ADMIN)
+- **Morador:** morador@reservai.com (RESIDENT)
+- **8 áreas comuns:** Salão de Festas, Churrasqueira, Piscina, Quadra Poliesportiva, Academia, Espaço Gourmet, Brinquedoteca, Salão de Jogos
+  - Salão de Festas e Espaço Gourmet exigem aprovação (`requiresApproval: true`)
+  - Churrasqueira funciona apenas sábados e domingos
+
+### Recriar dados do zero
+
+```bash
+npm run dev:prisma:seed
+```
+
+## 🧪 Testes
+
+```bash
+# Backend (unitários)
+npm run dev:api:test
+
+# Backend (E2E)
+npm run dev:api:test:e2e
+
+# Backend (com cobertura)
+npm run dev:api:test:cover
+
+# Frontend
+npm run dev:web:test
+```
 
 ## 🎨 5. Prototipação (Stitch)
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,8 @@ import { CommonAreasModule } from './common-areas/common-areas.module';
 import { ReservationsModule } from './reservations/reservations.module';
 import { CondominiumsModule } from './condominiums/condominiums.module';
 import { AnnouncementsModule } from './announcements/announcements.module';
+import { BlocksModule } from './blocks/blocks.module';
+import { UnitsModule } from './units/units.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { LoggerMiddleware } from './logger/logger.middleware';
 
@@ -24,6 +26,8 @@ import { LoggerMiddleware } from './logger/logger.middleware';
     ReservationsModule,
     CondominiumsModule,
     AnnouncementsModule,
+    BlocksModule,
+    UnitsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/blocks/blocks.controller.spec.ts
+++ b/apps/api/src/blocks/blocks.controller.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { BlocksController } from './blocks.controller';
+import { BlocksService } from './blocks.service';
+
+describe('BlocksController', () => {
+  let controller: BlocksController;
+  let service: BlocksService;
+
+  const mockAuthRequest = {
+    user: { sub: 'admin-id', email: 'admin@test.com', role: 'ADMIN', condominiumId: 'condo-id' },
+  };
+
+  const mockService = {
+    list: jest.fn(),
+    getById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BlocksController],
+      providers: [
+        { provide: BlocksService, useValue: mockService },
+        { provide: JwtService, useValue: { verifyAsync: jest.fn() } },
+        JwtAuthGuard,
+      ],
+    }).compile();
+
+    controller = module.get<BlocksController>(BlocksController);
+    service = module.get<BlocksService>(BlocksService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should call service.list with correct params', async () => {
+      const expected = { blocks: [], total: 0, page: 1, limit: 10, totalPages: 0 };
+      mockService.list.mockResolvedValue(expected);
+
+      const result = await controller.findAll(mockAuthRequest as any, 1, 10);
+
+      expect(service.list).toHaveBeenCalledWith({
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+        page: 1,
+        limit: 10,
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should call service.getById with correct params', async () => {
+      const expected = { id: 'block-id', name: 'Bloco A', condominiumId: 'condo-id' };
+      mockService.getById.mockResolvedValue(expected);
+
+      const result = await controller.findOne('block-id', mockAuthRequest as any);
+
+      expect(service.getById).toHaveBeenCalledWith('block-id', {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('create', () => {
+    it('should call service.create with correct params', async () => {
+      const dto = { name: 'Bloco A' };
+      const expected = { id: 'new-block', name: 'Bloco A', condominiumId: 'condo-id' };
+      mockService.create.mockResolvedValue(expected);
+
+      const result = await controller.create(dto as any, mockAuthRequest as any);
+
+      expect(service.create).toHaveBeenCalledWith(dto, {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('update', () => {
+    it('should call service.update with correct params', async () => {
+      const dto = { name: 'Bloco A Atualizado' };
+      const expected = { id: 'block-id', name: 'Bloco A Atualizado', condominiumId: 'condo-id' };
+      mockService.update.mockResolvedValue(expected);
+
+      const result = await controller.update('block-id', dto as any, mockAuthRequest as any);
+
+      expect(service.update).toHaveBeenCalledWith('block-id', dto, {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('delete', () => {
+    it('should call service.delete with correct params', async () => {
+      const expected = { message: 'Bloco removido com sucesso.' };
+      mockService.delete.mockResolvedValue(expected);
+
+      const result = await controller.delete('block-id', mockAuthRequest as any);
+
+      expect(service.delete).toHaveBeenCalledWith('block-id', {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/apps/api/src/blocks/blocks.controller.ts
+++ b/apps/api/src/blocks/blocks.controller.ts
@@ -1,0 +1,150 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  UseFilters,
+  Request,
+  HttpCode,
+  HttpStatus,
+  DefaultValuePipe,
+  ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TransformInterceptor } from '../common/interceptors/transform.interceptor';
+import { DomainExceptionFilter } from '../common/filters/domain-exception.filter';
+import { BlocksService } from './blocks.service';
+import { CreateBlockDto } from './dto/create-block.dto';
+import { UpdateBlockDto } from './dto/update-block.dto';
+import {
+  BlockListOutput,
+  BlockOutput,
+  BlockCreatedOutput,
+  BlockUpdatedOutput,
+  BlockDeletedOutput,
+} from './interfaces/blocks.interface';
+
+interface AuthRequest {
+  user: {
+    sub: string;
+    email: string;
+    role: string;
+    condominiumId: string;
+  };
+}
+
+@ApiTags('blocks')
+@ApiBearerAuth()
+@Controller('blocks')
+@UseGuards(JwtAuthGuard)
+@UseInterceptors(TransformInterceptor)
+@UseFilters(DomainExceptionFilter)
+export class BlocksController {
+  constructor(private readonly blocksService: BlocksService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Listar blocos do condomínio',
+    description: 'Lista todos os blocos do condomínio ordenados por nome.',
+  })
+  @ApiResponse({ status: 200, description: 'Lista de blocos retornada com sucesso.' })
+  @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  async findAll(
+    @Request() req: AuthRequest,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ): Promise<BlockListOutput> {
+    return this.blocksService.list({
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+      page,
+      limit,
+    });
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Buscar bloco pelo ID' })
+  @ApiParam({ name: 'id', description: 'UUID do bloco' })
+  @ApiResponse({ status: 200, description: 'Bloco encontrado.' })
+  @ApiResponse({ status: 404, description: 'Bloco não encontrado.' })
+  async findOne(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<BlockOutput> {
+    return this.blocksService.getById(id, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(new RolesGuard([Role.ADMIN]))
+  @ApiOperation({ summary: 'Criar bloco (Admin)' })
+  @ApiResponse({ status: 201, description: 'Bloco criado com sucesso.' })
+  @ApiResponse({ status: 409, description: 'Já existe bloco com este nome.' })
+  async create(
+    @Body() dto: CreateBlockDto,
+    @Request() req: AuthRequest,
+  ): Promise<BlockCreatedOutput> {
+    return this.blocksService.create(dto, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Patch(':id')
+  @UseGuards(new RolesGuard([Role.ADMIN]))
+  @ApiOperation({ summary: 'Atualizar bloco (Admin)' })
+  @ApiParam({ name: 'id', description: 'UUID do bloco' })
+  @ApiResponse({ status: 200, description: 'Bloco atualizado com sucesso.' })
+  @ApiResponse({ status: 404, description: 'Bloco não encontrado.' })
+  @ApiResponse({ status: 409, description: 'Já existe bloco com este nome.' })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateBlockDto,
+    @Request() req: AuthRequest,
+  ): Promise<BlockUpdatedOutput> {
+    return this.blocksService.update(id, dto, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Delete(':id')
+  @UseGuards(new RolesGuard([Role.ADMIN]))
+  @ApiOperation({ summary: 'Remover bloco (Admin)' })
+  @ApiParam({ name: 'id', description: 'UUID do bloco' })
+  @ApiResponse({ status: 200, description: 'Bloco removido com sucesso.' })
+  @ApiResponse({ status: 404, description: 'Bloco não encontrado.' })
+  @ApiResponse({ status: 409, description: 'Bloco possui unidades vinculadas.' })
+  async delete(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<BlockDeletedOutput> {
+    return this.blocksService.delete(id, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+}

--- a/apps/api/src/blocks/blocks.module.ts
+++ b/apps/api/src/blocks/blocks.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { BlocksController } from './blocks.controller';
+import { BlocksService } from './blocks.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [BlocksController],
+  providers: [BlocksService],
+  exports: [BlocksService],
+})
+export class BlocksModule {}

--- a/apps/api/src/blocks/blocks.service.spec.ts
+++ b/apps/api/src/blocks/blocks.service.spec.ts
@@ -1,0 +1,258 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { BlocksService } from './blocks.service';
+import {
+  BlockNotFoundException,
+  BlockAccessDeniedException,
+  BlockNameConflictException,
+  BlockHasUnitsException,
+} from './exceptions/block.exceptions';
+
+describe('BlocksService', () => {
+  let service: BlocksService;
+  let prisma: PrismaService;
+
+  const mockCondoId = 'condo-uuid-123';
+  const mockUserId = 'user-uuid-456';
+  const mockContext = { role: Role.ADMIN, condominiumId: mockCondoId, userId: mockUserId };
+  const mockResidentContext = { role: Role.RESIDENT, condominiumId: mockCondoId, userId: 'resident-id' };
+
+  const mockBlock = {
+    id: 'block-uuid-001',
+    name: 'Bloco A',
+    condominiumId: mockCondoId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockPrisma = {
+    block: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+    unit: {
+      count: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BlocksService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<BlocksService>(BlocksService);
+    prisma = module.get<PrismaService>(PrismaService);
+    jest.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('list', () => {
+    it('should list blocks of the condominium', async () => {
+      mockPrisma.block.findMany.mockResolvedValue([mockBlock]);
+      mockPrisma.block.count.mockResolvedValue(1);
+
+      const result = await service.list(mockContext);
+
+      expect(result.blocks).toHaveLength(1);
+      expect(result.blocks[0].name).toBe('Bloco A');
+      expect(result.total).toBe(1);
+      expect(mockPrisma.block.findMany).toHaveBeenCalledWith({
+        where: { condominiumId: mockCondoId },
+        orderBy: { name: 'asc' },
+        skip: 0,
+        take: 10,
+      });
+    });
+
+    it('should return empty list if no blocks', async () => {
+      mockPrisma.block.findMany.mockResolvedValue([]);
+      mockPrisma.block.count.mockResolvedValue(0);
+
+      const result = await service.list(mockContext);
+
+      expect(result.blocks).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should paginate results', async () => {
+      mockPrisma.block.findMany.mockResolvedValue([mockBlock]);
+      mockPrisma.block.count.mockResolvedValue(10);
+
+      const result = await service.list({ ...mockContext, page: 2, limit: 5 });
+
+      expect(mockPrisma.block.findMany).toHaveBeenCalledWith({
+        where: { condominiumId: mockCondoId },
+        orderBy: { name: 'asc' },
+        skip: 5,
+        take: 5,
+      });
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(5);
+      expect(result.totalPages).toBe(2);
+    });
+
+    it('should allow RESIDENT to list', async () => {
+      mockPrisma.block.findMany.mockResolvedValue([mockBlock]);
+      mockPrisma.block.count.mockResolvedValue(1);
+
+      const result = await service.list(mockResidentContext);
+
+      expect(result.blocks).toHaveLength(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return block by id', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+
+      const result = await service.getById('block-uuid-001', mockContext);
+
+      expect(result.id).toBe('block-uuid-001');
+      expect(result.name).toBe('Bloco A');
+    });
+
+    it('should throw BlockNotFoundException if not found', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(null);
+
+      await expect(service.getById('inexistente', mockContext))
+        .rejects.toThrow(BlockNotFoundException);
+    });
+
+    it('should allow RESIDENT to get by id', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+
+      const result = await service.getById('block-uuid-001', mockResidentContext);
+
+      expect(result.id).toBe('block-uuid-001');
+    });
+  });
+
+  describe('create', () => {
+    const createDto = { name: 'Bloco A' };
+
+    it('should create a block', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(null);
+      mockPrisma.block.create.mockResolvedValue(mockBlock);
+
+      const result = await service.create(createDto, mockContext);
+
+      expect(result.id).toBe('block-uuid-001');
+      expect(result.name).toBe('Bloco A');
+      expect(mockPrisma.block.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Bloco A',
+          condominiumId: mockCondoId,
+        },
+      });
+    });
+
+    it('should throw BlockAccessDeniedException if not ADMIN', async () => {
+      await expect(service.create(createDto, mockResidentContext))
+        .rejects.toThrow(BlockAccessDeniedException);
+    });
+
+    it('should throw BlockNameConflictException if name already exists in condominium', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+
+      await expect(service.create(createDto, mockContext))
+        .rejects.toThrow(BlockNameConflictException);
+    });
+  });
+
+  describe('update', () => {
+    const updateDto = { name: 'Bloco A Atualizado' };
+
+    it('should update block name', async () => {
+      mockPrisma.block.findFirst
+        .mockResolvedValueOnce(mockBlock)
+        .mockResolvedValueOnce(null);
+      mockPrisma.block.update.mockResolvedValue({
+        ...mockBlock,
+        name: 'Bloco A Atualizado',
+        updatedAt: new Date(),
+      });
+
+      const result = await service.update('block-uuid-001', updateDto, mockContext);
+
+      expect(result.name).toBe('Bloco A Atualizado');
+    });
+
+    it('should throw BlockNotFoundException if not found', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(null);
+
+      await expect(service.update('inexistente', updateDto, mockContext))
+        .rejects.toThrow(BlockNotFoundException);
+    });
+
+    it('should throw BlockAccessDeniedException if not ADMIN', async () => {
+      await expect(service.update('block-uuid-001', updateDto, mockResidentContext))
+        .rejects.toThrow(BlockAccessDeniedException);
+    });
+
+    it('should throw BlockNameConflictException if new name already exists', async () => {
+      const outroBloco = { ...mockBlock, id: 'outro-block', name: 'Bloco B' };
+      mockPrisma.block.findFirst
+        .mockResolvedValueOnce(mockBlock)
+        .mockResolvedValueOnce(outroBloco);
+
+      await expect(service.update('block-uuid-001', { name: 'Bloco B' }, mockContext))
+        .rejects.toThrow(BlockNameConflictException);
+    });
+
+    it('should allow keeping the same name', async () => {
+      mockPrisma.block.findFirst
+        .mockResolvedValueOnce(mockBlock)
+        .mockResolvedValueOnce(mockBlock);
+      mockPrisma.block.update.mockResolvedValue(mockBlock);
+
+      const result = await service.update('block-uuid-001', { name: 'Bloco A' }, mockContext);
+
+      expect(result.name).toBe('Bloco A');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete block if it has no units', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+      mockPrisma.unit.count.mockResolvedValue(0);
+      mockPrisma.block.delete.mockResolvedValue(mockBlock);
+
+      const result = await service.delete('block-uuid-001', mockContext);
+
+      expect(result.message).toBe('Bloco removido com sucesso.');
+      expect(mockPrisma.block.delete).toHaveBeenCalledWith({ where: { id: 'block-uuid-001' } });
+    });
+
+    it('should throw BlockNotFoundException if not found', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(null);
+
+      await expect(service.delete('inexistente', mockContext))
+        .rejects.toThrow(BlockNotFoundException);
+    });
+
+    it('should throw BlockAccessDeniedException if not ADMIN', async () => {
+      await expect(service.delete('block-uuid-001', mockResidentContext))
+        .rejects.toThrow(BlockAccessDeniedException);
+    });
+
+    it('should throw BlockHasUnitsException if block has units', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+      mockPrisma.unit.count.mockResolvedValue(5);
+
+      await expect(service.delete('block-uuid-001', mockContext))
+        .rejects.toThrow(BlockHasUnitsException);
+    });
+  });
+});

--- a/apps/api/src/blocks/blocks.service.ts
+++ b/apps/api/src/blocks/blocks.service.ts
@@ -1,0 +1,170 @@
+import { Injectable } from '@nestjs/common';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateBlockDto } from './dto/create-block.dto';
+import { UpdateBlockDto } from './dto/update-block.dto';
+import {
+  BlockOutput,
+  BlockListOutput,
+  BlockCreatedOutput,
+  BlockUpdatedOutput,
+  BlockDeletedOutput,
+} from './interfaces/blocks.interface';
+import {
+  BlockNotFoundException,
+  BlockAccessDeniedException,
+  BlockNameConflictException,
+  BlockHasUnitsException,
+} from './exceptions/block.exceptions';
+
+interface ServiceContext {
+  role: string;
+  condominiumId: string | null;
+  userId: string;
+  page?: number;
+  limit?: number;
+}
+
+@Injectable()
+export class BlocksService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(context: ServiceContext): Promise<BlockListOutput> {
+    const page = context.page ?? 1;
+    const limit = context.limit ?? 10;
+    const skip = (page - 1) * limit;
+    const condominiumId = context.condominiumId as string;
+
+    const where = { condominiumId };
+
+    const [blocks, total] = await Promise.all([
+      this.prisma.block.findMany({
+        where,
+        orderBy: { name: 'asc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.block.count({ where }),
+    ]);
+
+    return {
+      blocks,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async getById(id: string, context: ServiceContext): Promise<BlockOutput> {
+    const condominiumId = context.condominiumId as string;
+
+    const block = await this.prisma.block.findFirst({
+      where: { id, condominiumId },
+    });
+
+    if (!block) {
+      throw new BlockNotFoundException(id);
+    }
+
+    return block;
+  }
+
+  async create(dto: CreateBlockDto, context: ServiceContext): Promise<BlockCreatedOutput> {
+    if (context.role !== Role.ADMIN) {
+      throw new BlockAccessDeniedException('criar');
+    }
+
+    const condominiumId = context.condominiumId as string;
+
+    const existing = await this.prisma.block.findFirst({
+      where: { name: dto.name, condominiumId },
+    });
+
+    if (existing) {
+      throw new BlockNameConflictException(dto.name);
+    }
+
+    const block = await this.prisma.block.create({
+      data: {
+        name: dto.name,
+        condominiumId,
+      },
+    });
+
+    return {
+      id: block.id,
+      name: block.name,
+      condominiumId: block.condominiumId,
+      createdAt: block.createdAt,
+    };
+  }
+
+  async update(id: string, dto: UpdateBlockDto, context: ServiceContext): Promise<BlockUpdatedOutput> {
+    if (context.role !== Role.ADMIN) {
+      throw new BlockAccessDeniedException('atualizar');
+    }
+
+    const condominiumId = context.condominiumId as string;
+
+    const block = await this.prisma.block.findFirst({
+      where: { id, condominiumId },
+    });
+
+    if (!block) {
+      throw new BlockNotFoundException(id);
+    }
+
+    if (dto.name && dto.name !== block.name) {
+      const existing = await this.prisma.block.findFirst({
+        where: { name: dto.name, condominiumId },
+      });
+
+      if (existing) {
+        throw new BlockNameConflictException(dto.name);
+      }
+    }
+
+    const updated = await this.prisma.block.update({
+      where: { id },
+      data: {
+        ...(dto.name && { name: dto.name }),
+      },
+    });
+
+    return {
+      id: updated.id,
+      name: updated.name,
+      condominiumId: updated.condominiumId,
+      updatedAt: updated.updatedAt,
+    };
+  }
+
+  async delete(id: string, context: ServiceContext): Promise<BlockDeletedOutput> {
+    if (context.role !== Role.ADMIN) {
+      throw new BlockAccessDeniedException('remover');
+    }
+
+    const condominiumId = context.condominiumId as string;
+
+    const block = await this.prisma.block.findFirst({
+      where: { id, condominiumId },
+    });
+
+    if (!block) {
+      throw new BlockNotFoundException(id);
+    }
+
+    const unitsCount = await this.prisma.unit.count({
+      where: { blockId: id },
+    });
+
+    if (unitsCount > 0) {
+      throw new BlockHasUnitsException(id);
+    }
+
+    await this.prisma.block.delete({ where: { id } });
+
+    return { message: 'Bloco removido com sucesso.' };
+  }
+}

--- a/apps/api/src/blocks/dto/create-block.dto.ts
+++ b/apps/api/src/blocks/dto/create-block.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty, MaxLength, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateBlockDto {
+  @ApiProperty({ example: 'Bloco A', description: 'Nome do bloco' })
+  @IsString({ message: 'O nome deve ser um texto válido.' })
+  @IsNotEmpty({ message: 'O nome é obrigatório.' })
+  @MinLength(2, { message: 'O nome deve ter no mínimo 2 caracteres.' })
+  @MaxLength(50, { message: 'O nome deve ter no máximo 50 caracteres.' })
+  name: string;
+}

--- a/apps/api/src/blocks/dto/update-block.dto.ts
+++ b/apps/api/src/blocks/dto/update-block.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsOptional, MinLength, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateBlockDto {
+  @ApiPropertyOptional({ example: 'Bloco A - Atualizado', description: 'Novo nome do bloco' })
+  @IsString({ message: 'O nome deve ser um texto válido.' })
+  @IsOptional()
+  @MinLength(2, { message: 'O nome deve ter no mínimo 2 caracteres.' })
+  @MaxLength(50, { message: 'O nome deve ter no máximo 50 caracteres.' })
+  name?: string;
+}

--- a/apps/api/src/blocks/exceptions/block.exceptions.ts
+++ b/apps/api/src/blocks/exceptions/block.exceptions.ts
@@ -1,0 +1,46 @@
+import { HttpStatus } from '@nestjs/common';
+import { DomainException } from '../../common-areas/exceptions/common-area.exceptions';
+
+export class BlockNotFoundException extends DomainException {
+  constructor(blockId: string) {
+    super({
+      code: 'BLOCK_NOT_FOUND',
+      message: `Bloco com ID ${blockId} não foi encontrado.`,
+      statusCode: HttpStatus.NOT_FOUND,
+      details: { blockId },
+    });
+  }
+}
+
+export class BlockAccessDeniedException extends DomainException {
+  constructor(action: string) {
+    super({
+      code: 'BLOCK_ACCESS_DENIED',
+      message: `Apenas administradores podem ${action} blocos.`,
+      statusCode: HttpStatus.FORBIDDEN,
+      details: { action },
+    });
+  }
+}
+
+export class BlockNameConflictException extends DomainException {
+  constructor(name: string) {
+    super({
+      code: 'BLOCK_NAME_CONFLICT',
+      message: `Já existe um bloco com o nome "${name}".`,
+      statusCode: HttpStatus.CONFLICT,
+      details: { name },
+    });
+  }
+}
+
+export class BlockHasUnitsException extends DomainException {
+  constructor(blockId: string) {
+    super({
+      code: 'BLOCK_HAS_UNITS',
+      message: `Bloco com ID ${blockId} possui unidades vinculadas e não pode ser removido.`,
+      statusCode: HttpStatus.CONFLICT,
+      details: { blockId },
+    });
+  }
+}

--- a/apps/api/src/blocks/exceptions/index.ts
+++ b/apps/api/src/blocks/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './block.exceptions';

--- a/apps/api/src/blocks/interfaces/blocks.interface.ts
+++ b/apps/api/src/blocks/interfaces/blocks.interface.ts
@@ -1,0 +1,33 @@
+export interface BlockOutput {
+  id: string;
+  name: string;
+  condominiumId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface BlockListOutput {
+  blocks: BlockOutput[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface BlockCreatedOutput {
+  id: string;
+  name: string;
+  condominiumId: string;
+  createdAt: Date;
+}
+
+export interface BlockUpdatedOutput {
+  id: string;
+  name: string;
+  condominiumId: string;
+  updatedAt: Date;
+}
+
+export interface BlockDeletedOutput {
+  message: string;
+}

--- a/apps/api/src/units/dto/create-unit.dto.ts
+++ b/apps/api/src/units/dto/create-unit.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsNotEmpty, MaxLength, MinLength, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateUnitDto {
+  @ApiProperty({ example: '101', description: 'Número da unidade' })
+  @IsString({ message: 'O número deve ser um texto válido.' })
+  @IsNotEmpty({ message: 'O número é obrigatório.' })
+  @MinLength(1, { message: 'O número deve ter no mínimo 1 caractere.' })
+  @MaxLength(20, { message: 'O número deve ter no máximo 20 caracteres.' })
+  number: string;
+
+  @ApiProperty({ example: 'uuid-do-bloco', description: 'UUID do bloco' })
+  @IsUUID('4', { message: 'O ID do bloco deve ser um UUID válido.' })
+  @IsNotEmpty({ message: 'O bloco é obrigatório.' })
+  blockId: string;
+}

--- a/apps/api/src/units/dto/update-unit.dto.ts
+++ b/apps/api/src/units/dto/update-unit.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsOptional, MinLength, MaxLength, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateUnitDto {
+  @ApiPropertyOptional({ example: '102', description: 'Novo número da unidade' })
+  @IsString({ message: 'O número deve ser um texto válido.' })
+  @IsOptional()
+  @MinLength(1, { message: 'O número deve ter no mínimo 1 caractere.' })
+  @MaxLength(20, { message: 'O número deve ter no máximo 20 caracteres.' })
+  number?: string;
+
+  @ApiPropertyOptional({ example: 'uuid-do-bloco', description: 'UUID do bloco' })
+  @IsUUID('4', { message: 'O ID do bloco deve ser um UUID válido.' })
+  @IsOptional()
+  blockId?: string;
+}

--- a/apps/api/src/units/exceptions/index.ts
+++ b/apps/api/src/units/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './unit.exceptions';

--- a/apps/api/src/units/exceptions/unit.exceptions.ts
+++ b/apps/api/src/units/exceptions/unit.exceptions.ts
@@ -1,0 +1,57 @@
+import { HttpStatus } from '@nestjs/common';
+import { DomainException } from '../../common-areas/exceptions/common-area.exceptions';
+
+export class UnitNotFoundException extends DomainException {
+  constructor(unitId: string) {
+    super({
+      code: 'UNIT_NOT_FOUND',
+      message: `Unidade com ID ${unitId} não foi encontrada.`,
+      statusCode: HttpStatus.NOT_FOUND,
+      details: { unitId },
+    });
+  }
+}
+
+export class UnitAccessDeniedException extends DomainException {
+  constructor(action: string) {
+    super({
+      code: 'UNIT_ACCESS_DENIED',
+      message: `Apenas administradores podem ${action} unidades.`,
+      statusCode: HttpStatus.FORBIDDEN,
+      details: { action },
+    });
+  }
+}
+
+export class UnitNumberConflictException extends DomainException {
+  constructor(number: string) {
+    super({
+      code: 'UNIT_NUMBER_CONFLICT',
+      message: `Já existe uma unidade com o número "${number}".`,
+      statusCode: HttpStatus.CONFLICT,
+      details: { number },
+    });
+  }
+}
+
+export class BlockNotFoundException extends DomainException {
+  constructor(blockId: string) {
+    super({
+      code: 'BLOCK_NOT_FOUND',
+      message: `Bloco com ID ${blockId} não foi encontrado.`,
+      statusCode: HttpStatus.NOT_FOUND,
+      details: { blockId },
+    });
+  }
+}
+
+export class UnitHasResidentsException extends DomainException {
+  constructor(unitId: string) {
+    super({
+      code: 'UNIT_HAS_RESIDENTS',
+      message: `Unidade com ID ${unitId} possui moradores vinculados e não pode ser removida.`,
+      statusCode: HttpStatus.CONFLICT,
+      details: { unitId },
+    });
+  }
+}

--- a/apps/api/src/units/interfaces/units.interface.ts
+++ b/apps/api/src/units/interfaces/units.interface.ts
@@ -1,0 +1,34 @@
+export interface UnitOutput {
+  id: string;
+  number: string;
+  blockId: string;
+  blockName?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface UnitListOutput {
+  units: UnitOutput[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface UnitCreatedOutput {
+  id: string;
+  number: string;
+  blockId: string;
+  createdAt: Date;
+}
+
+export interface UnitUpdatedOutput {
+  id: string;
+  number: string;
+  blockId: string;
+  updatedAt: Date;
+}
+
+export interface UnitDeletedOutput {
+  message: string;
+}

--- a/apps/api/src/units/units.controller.spec.ts
+++ b/apps/api/src/units/units.controller.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UnitsController } from './units.controller';
+import { UnitsService } from './units.service';
+
+describe('UnitsController', () => {
+  let controller: UnitsController;
+  let service: UnitsService;
+
+  const mockAuthRequest = {
+    user: { sub: 'admin-id', email: 'admin@test.com', role: 'ADMIN', condominiumId: 'condo-id' },
+  };
+
+  const mockService = {
+    list: jest.fn(),
+    getById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UnitsController],
+      providers: [
+        { provide: UnitsService, useValue: mockService },
+        { provide: JwtService, useValue: { verifyAsync: jest.fn() } },
+        JwtAuthGuard,
+      ],
+    }).compile();
+
+    controller = module.get<UnitsController>(UnitsController);
+    service = module.get<UnitsService>(UnitsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should call service.list with correct params', async () => {
+      const expected = { units: [], total: 0, page: 1, limit: 10, totalPages: 0 };
+      mockService.list.mockResolvedValue(expected);
+
+      const result = await controller.findAll(mockAuthRequest as any, 1, 10, undefined);
+
+      expect(service.list).toHaveBeenCalledWith({
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+        page: 1,
+        limit: 10,
+      });
+      expect(result).toEqual(expected);
+    });
+
+    it('should pass blockId filter when provided', async () => {
+      const expected = { units: [], total: 0, page: 1, limit: 10, totalPages: 0 };
+      mockService.list.mockResolvedValue(expected);
+
+      const result = await controller.findAll(mockAuthRequest as any, 1, 10, 'block-id');
+
+      expect(service.list).toHaveBeenCalledWith({
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+        page: 1,
+        limit: 10,
+        blockId: 'block-id',
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('should call service.getById with correct params', async () => {
+      const expected = { id: 'unit-id', number: '101', blockId: 'block-id' };
+      mockService.getById.mockResolvedValue(expected);
+
+      const result = await controller.findOne('unit-id', mockAuthRequest as any);
+
+      expect(service.getById).toHaveBeenCalledWith('unit-id', {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('create', () => {
+    it('should call service.create with correct params', async () => {
+      const dto = { number: '101', blockId: 'block-id' };
+      const expected = { id: 'new-unit', number: '101', blockId: 'block-id' };
+      mockService.create.mockResolvedValue(expected);
+
+      const result = await controller.create(dto as any, mockAuthRequest as any);
+
+      expect(service.create).toHaveBeenCalledWith(dto, {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('update', () => {
+    it('should call service.update with correct params', async () => {
+      const dto = { number: '102' };
+      const expected = { id: 'unit-id', number: '102', blockId: 'block-id' };
+      mockService.update.mockResolvedValue(expected);
+
+      const result = await controller.update('unit-id', dto as any, mockAuthRequest as any);
+
+      expect(service.update).toHaveBeenCalledWith('unit-id', dto, {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('delete', () => {
+    it('should call service.delete with correct params', async () => {
+      const expected = { message: 'Unidade removida com sucesso.' };
+      mockService.delete.mockResolvedValue(expected);
+
+      const result = await controller.delete('unit-id', mockAuthRequest as any);
+
+      expect(service.delete).toHaveBeenCalledWith('unit-id', {
+        role: 'ADMIN',
+        condominiumId: 'condo-id',
+        userId: 'admin-id',
+      });
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/apps/api/src/units/units.controller.ts
+++ b/apps/api/src/units/units.controller.ts
@@ -1,0 +1,154 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  UseFilters,
+  Request,
+  HttpCode,
+  HttpStatus,
+  DefaultValuePipe,
+  ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { Role } from '@prisma/client';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TransformInterceptor } from '../common/interceptors/transform.interceptor';
+import { DomainExceptionFilter } from '../common/filters/domain-exception.filter';
+import { UnitsService } from './units.service';
+import { CreateUnitDto } from './dto/create-unit.dto';
+import { UpdateUnitDto } from './dto/update-unit.dto';
+import {
+  UnitListOutput,
+  UnitOutput,
+  UnitCreatedOutput,
+  UnitUpdatedOutput,
+  UnitDeletedOutput,
+} from './interfaces/units.interface';
+
+interface AuthRequest {
+  user: {
+    sub: string;
+    email: string;
+    role: string;
+    condominiumId: string;
+  };
+}
+
+@ApiTags('units')
+@ApiBearerAuth()
+@Controller('units')
+@UseGuards(JwtAuthGuard)
+@UseInterceptors(TransformInterceptor)
+@UseFilters(DomainExceptionFilter)
+export class UnitsController {
+  constructor(private readonly unitsService: UnitsService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Listar unidades do condomínio',
+    description: 'Lista todas as unidades do condomínio ordenadas por número. Pode filtrar por bloco.',
+  })
+  @ApiQuery({ name: 'blockId', required: false, description: 'Filtrar por UUID do bloco' })
+  @ApiResponse({ status: 200, description: 'Lista de unidades retornada com sucesso.' })
+  @ApiResponse({ status: 401, description: 'Não autenticado.' })
+  async findAll(
+    @Request() req: AuthRequest,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('blockId') blockId?: string,
+  ): Promise<UnitListOutput> {
+    return this.unitsService.list({
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+      page,
+      limit,
+      blockId,
+    });
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Buscar unidade pelo ID' })
+  @ApiParam({ name: 'id', description: 'UUID da unidade' })
+  @ApiResponse({ status: 200, description: 'Unidade encontrada.' })
+  @ApiResponse({ status: 404, description: 'Unidade não encontrada.' })
+  async findOne(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<UnitOutput> {
+    return this.unitsService.getById(id, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(new RolesGuard([Role.ADMIN]))
+  @ApiOperation({ summary: 'Criar unidade (Admin)' })
+  @ApiResponse({ status: 201, description: 'Unidade criada com sucesso.' })
+  @ApiResponse({ status: 409, description: 'Já existe unidade com este número.' })
+  async create(
+    @Body() dto: CreateUnitDto,
+    @Request() req: AuthRequest,
+  ): Promise<UnitCreatedOutput> {
+    return this.unitsService.create(dto, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Patch(':id')
+  @UseGuards(new RolesGuard([Role.ADMIN]))
+  @ApiOperation({ summary: 'Atualizar unidade (Admin)' })
+  @ApiParam({ name: 'id', description: 'UUID da unidade' })
+  @ApiResponse({ status: 200, description: 'Unidade atualizada com sucesso.' })
+  @ApiResponse({ status: 404, description: 'Unidade não encontrada.' })
+  @ApiResponse({ status: 409, description: 'Já existe unidade com este número.' })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateUnitDto,
+    @Request() req: AuthRequest,
+  ): Promise<UnitUpdatedOutput> {
+    return this.unitsService.update(id, dto, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+
+  @Delete(':id')
+  @UseGuards(new RolesGuard([Role.ADMIN]))
+  @ApiOperation({ summary: 'Remover unidade (Admin)' })
+  @ApiParam({ name: 'id', description: 'UUID da unidade' })
+  @ApiResponse({ status: 200, description: 'Unidade removida com sucesso.' })
+  @ApiResponse({ status: 404, description: 'Unidade não encontrada.' })
+  @ApiResponse({ status: 409, description: 'Unidade possui moradores vinculados.' })
+  async delete(
+    @Param('id') id: string,
+    @Request() req: AuthRequest,
+  ): Promise<UnitDeletedOutput> {
+    return this.unitsService.delete(id, {
+      role: req.user.role,
+      condominiumId: req.user.condominiumId,
+      userId: req.user.sub,
+    });
+  }
+}

--- a/apps/api/src/units/units.module.ts
+++ b/apps/api/src/units/units.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UnitsController } from './units.controller';
+import { UnitsService } from './units.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UnitsController],
+  providers: [UnitsService],
+  exports: [UnitsService],
+})
+export class UnitsModule {}

--- a/apps/api/src/units/units.service.spec.ts
+++ b/apps/api/src/units/units.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { UnitsService } from './units.service';
+import {
+  UnitNotFoundException,
+  UnitAccessDeniedException,
+  UnitNumberConflictException,
+  BlockNotFoundException,
+  UnitHasResidentsException,
+} from './exceptions/unit.exceptions';
+
+describe('UnitsService', () => {
+  let service: UnitsService;
+  let prisma: PrismaService;
+
+  const mockCondoId = 'condo-uuid-123';
+  const mockBlockId = 'block-uuid-001';
+  const mockUserId = 'user-uuid-456';
+  const mockContext = { role: Role.ADMIN, condominiumId: mockCondoId, userId: mockUserId };
+  const mockResidentContext = { role: Role.RESIDENT, condominiumId: mockCondoId, userId: 'resident-id' };
+
+  const mockUnit = {
+    id: 'unit-uuid-001',
+    number: '101',
+    blockId: mockBlockId,
+    block: { id: mockBlockId, name: 'Bloco A' },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockBlock = {
+    id: mockBlockId,
+    name: 'Bloco A',
+    condominiumId: mockCondoId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockPrisma = {
+    unit: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+    block: {
+      findFirst: jest.fn(),
+    },
+    resident: {
+      count: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UnitsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<UnitsService>(UnitsService);
+    prisma = module.get<PrismaService>(PrismaService);
+    jest.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('list', () => {
+    it('should list units of the condominium with block info', async () => {
+      mockPrisma.unit.findMany.mockResolvedValue([mockUnit]);
+      mockPrisma.unit.count.mockResolvedValue(1);
+
+      const result = await service.list(mockContext);
+
+      expect(result.units).toHaveLength(1);
+      expect(result.units[0].number).toBe('101');
+      expect(result.units[0].blockName).toBe('Bloco A');
+      expect(result.total).toBe(1);
+      expect(mockPrisma.unit.findMany).toHaveBeenCalledWith({
+        where: { block: { condominiumId: mockCondoId } },
+        include: { block: { select: { id: true, name: true } } },
+        orderBy: { number: 'asc' },
+        skip: 0,
+        take: 10,
+      });
+    });
+
+    it('should filter units by blockId', async () => {
+      mockPrisma.unit.findMany.mockResolvedValue([mockUnit]);
+      mockPrisma.unit.count.mockResolvedValue(1);
+
+      const result = await service.list({ ...mockContext, blockId: mockBlockId });
+
+      expect(mockPrisma.unit.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { blockId: mockBlockId, block: { condominiumId: mockCondoId } },
+        }),
+      );
+      expect(result.units).toHaveLength(1);
+    });
+
+    it('should return empty list if no units', async () => {
+      mockPrisma.unit.findMany.mockResolvedValue([]);
+      mockPrisma.unit.count.mockResolvedValue(0);
+
+      const result = await service.list(mockContext);
+
+      expect(result.units).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should allow RESIDENT to list', async () => {
+      mockPrisma.unit.findMany.mockResolvedValue([mockUnit]);
+      mockPrisma.unit.count.mockResolvedValue(1);
+
+      const result = await service.list(mockResidentContext);
+
+      expect(result.units).toHaveLength(1);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return unit by id', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+
+      const result = await service.getById('unit-uuid-001', mockContext);
+
+      expect(result.number).toBe('101');
+    });
+
+    it('should throw UnitNotFoundException if not found', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(null);
+
+      await expect(service.getById('inexistente', mockContext))
+        .rejects.toThrow(UnitNotFoundException);
+    });
+
+    it('should allow RESIDENT to get by id', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+
+      const result = await service.getById('unit-uuid-001', mockResidentContext);
+
+      expect(result.number).toBe('101');
+    });
+  });
+
+  describe('create', () => {
+    const createDto = { number: '101', blockId: mockBlockId };
+
+    it('should create a unit', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+      mockPrisma.unit.findFirst.mockResolvedValue(null);
+      mockPrisma.unit.create.mockResolvedValue(mockUnit);
+
+      const result = await service.create(createDto, mockContext);
+
+      expect(result.number).toBe('101');
+      expect(result.blockId).toBe(mockBlockId);
+      expect(mockPrisma.unit.create).toHaveBeenCalledWith({
+        data: { number: '101', blockId: mockBlockId },
+      });
+    });
+
+    it('should throw UnitAccessDeniedException if not ADMIN', async () => {
+      await expect(service.create(createDto, mockResidentContext))
+        .rejects.toThrow(UnitAccessDeniedException);
+    });
+
+    it('should throw BlockNotFoundException if block does not exist in condominium', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(null);
+
+      await expect(service.create(createDto, mockContext))
+        .rejects.toThrow(BlockNotFoundException);
+    });
+
+    it('should throw UnitNumberConflictException if number already exists', async () => {
+      mockPrisma.block.findFirst.mockResolvedValue(mockBlock);
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+
+      await expect(service.create(createDto, mockContext))
+        .rejects.toThrow(UnitNumberConflictException);
+    });
+  });
+
+  describe('update', () => {
+    const updateDto = { number: '102' };
+
+    it('should update unit number', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+      mockPrisma.unit.findFirst.mockResolvedValueOnce(mockUnit);
+      mockPrisma.unit.findFirst.mockResolvedValueOnce(null);
+      mockPrisma.unit.update.mockResolvedValue({ ...mockUnit, number: '102', updatedAt: new Date() });
+
+      const result = await service.update('unit-uuid-001', updateDto, mockContext);
+
+      expect(result.number).toBe('102');
+    });
+
+    it('should throw UnitNotFoundException if not found', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(null);
+
+      await expect(service.update('inexistente', updateDto, mockContext))
+        .rejects.toThrow(UnitNotFoundException);
+    });
+
+    it('should throw UnitAccessDeniedException if not ADMIN', async () => {
+      await expect(service.update('unit-uuid-001', updateDto, mockResidentContext))
+        .rejects.toThrow(UnitAccessDeniedException);
+    });
+
+    it('should throw UnitNumberConflictException if new number already exists', async () => {
+      const outraUnit = { ...mockUnit, id: 'outra-unit', number: '102' };
+      mockPrisma.unit.findFirst
+        .mockResolvedValueOnce(mockUnit)
+        .mockResolvedValueOnce(outraUnit);
+
+      await expect(service.update('unit-uuid-001', { number: '102' }, mockContext))
+        .rejects.toThrow(UnitNumberConflictException);
+    });
+
+    it('should validate blockId when updating block', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+      mockPrisma.block.findFirst.mockResolvedValue(null);
+
+      await expect(service.update('unit-uuid-001', { blockId: 'block-inexistente' }, mockContext))
+        .rejects.toThrow(BlockNotFoundException);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete unit if it has no residents', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+      mockPrisma.resident.count.mockResolvedValue(0);
+      mockPrisma.unit.delete.mockResolvedValue(mockUnit);
+
+      const result = await service.delete('unit-uuid-001', mockContext);
+
+      expect(result.message).toBe('Unidade removida com sucesso.');
+    });
+
+    it('should throw UnitNotFoundException if not found', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(null);
+
+      await expect(service.delete('inexistente', mockContext))
+        .rejects.toThrow(UnitNotFoundException);
+    });
+
+    it('should throw UnitAccessDeniedException if not ADMIN', async () => {
+      await expect(service.delete('unit-uuid-001', mockResidentContext))
+        .rejects.toThrow(UnitAccessDeniedException);
+    });
+
+    it('should throw UnitHasResidentsException if unit has residents', async () => {
+      mockPrisma.unit.findFirst.mockResolvedValue(mockUnit);
+      mockPrisma.resident.count.mockResolvedValue(2);
+
+      await expect(service.delete('unit-uuid-001', mockContext))
+        .rejects.toThrow(UnitHasResidentsException);
+    });
+  });
+});

--- a/apps/api/src/units/units.service.ts
+++ b/apps/api/src/units/units.service.ts
@@ -1,0 +1,210 @@
+import { Injectable } from '@nestjs/common';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateUnitDto } from './dto/create-unit.dto';
+import { UpdateUnitDto } from './dto/update-unit.dto';
+import {
+  UnitOutput,
+  UnitListOutput,
+  UnitCreatedOutput,
+  UnitUpdatedOutput,
+  UnitDeletedOutput,
+} from './interfaces/units.interface';
+import {
+  UnitNotFoundException,
+  UnitAccessDeniedException,
+  UnitNumberConflictException,
+  BlockNotFoundException,
+  UnitHasResidentsException,
+} from './exceptions/unit.exceptions';
+
+interface ServiceContext {
+  role: string;
+  condominiumId: string | null;
+  userId: string;
+  page?: number;
+  limit?: number;
+  blockId?: string;
+}
+
+@Injectable()
+export class UnitsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(context: ServiceContext): Promise<UnitListOutput> {
+    const page = context.page ?? 1;
+    const limit = context.limit ?? 10;
+    const skip = (page - 1) * limit;
+    const condominiumId = context.condominiumId as string;
+
+    const where: any = { block: { condominiumId } };
+    if (context.blockId) {
+      where.blockId = context.blockId;
+    }
+
+    const [units, total] = await Promise.all([
+      this.prisma.unit.findMany({
+        where,
+        include: { block: { select: { id: true, name: true } } },
+        orderBy: { number: 'asc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.unit.count({ where }),
+    ]);
+
+    return {
+      units: units.map((unit) => ({
+        id: unit.id,
+        number: unit.number,
+        blockId: unit.blockId,
+        blockName: unit.block.name,
+        createdAt: unit.createdAt,
+        updatedAt: unit.updatedAt,
+      })),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async getById(id: string, context: ServiceContext): Promise<UnitOutput> {
+    const condominiumId = context.condominiumId as string;
+
+    const unit = await this.prisma.unit.findFirst({
+      where: { id, block: { condominiumId } },
+      include: { block: { select: { id: true, name: true } } },
+    });
+
+    if (!unit) {
+      throw new UnitNotFoundException(id);
+    }
+
+    return {
+      id: unit.id,
+      number: unit.number,
+      blockId: unit.blockId,
+      blockName: unit.block.name,
+      createdAt: unit.createdAt,
+      updatedAt: unit.updatedAt,
+    };
+  }
+
+  async create(dto: CreateUnitDto, context: ServiceContext): Promise<UnitCreatedOutput> {
+    if (context.role !== Role.ADMIN) {
+      throw new UnitAccessDeniedException('criar');
+    }
+
+    const condominiumId = context.condominiumId as string;
+
+    const block = await this.prisma.block.findFirst({
+      where: { id: dto.blockId, condominiumId },
+    });
+
+    if (!block) {
+      throw new BlockNotFoundException(dto.blockId);
+    }
+
+    const existing = await this.prisma.unit.findFirst({
+      where: { number: dto.number },
+    });
+
+    if (existing) {
+      throw new UnitNumberConflictException(dto.number);
+    }
+
+    const unit = await this.prisma.unit.create({
+      data: {
+        number: dto.number,
+        blockId: dto.blockId,
+      },
+    });
+
+    return {
+      id: unit.id,
+      number: unit.number,
+      blockId: unit.blockId,
+      createdAt: unit.createdAt,
+    };
+  }
+
+  async update(id: string, dto: UpdateUnitDto, context: ServiceContext): Promise<UnitUpdatedOutput> {
+    if (context.role !== Role.ADMIN) {
+      throw new UnitAccessDeniedException('atualizar');
+    }
+
+    const condominiumId = context.condominiumId as string;
+
+    const unit = await this.prisma.unit.findFirst({
+      where: { id, block: { condominiumId } },
+    });
+
+    if (!unit) {
+      throw new UnitNotFoundException(id);
+    }
+
+    if (dto.blockId) {
+      const block = await this.prisma.block.findFirst({
+        where: { id: dto.blockId, condominiumId },
+      });
+
+      if (!block) {
+        throw new BlockNotFoundException(dto.blockId);
+      }
+    }
+
+    if (dto.number && dto.number !== unit.number) {
+      const existing = await this.prisma.unit.findFirst({
+        where: { number: dto.number },
+      });
+
+      if (existing) {
+        throw new UnitNumberConflictException(dto.number);
+      }
+    }
+
+    const updated = await this.prisma.unit.update({
+      where: { id },
+      data: {
+        ...(dto.number && { number: dto.number }),
+        ...(dto.blockId && { blockId: dto.blockId }),
+      },
+    });
+
+    return {
+      id: updated.id,
+      number: updated.number,
+      blockId: updated.blockId,
+      updatedAt: updated.updatedAt,
+    };
+  }
+
+  async delete(id: string, context: ServiceContext): Promise<UnitDeletedOutput> {
+    if (context.role !== Role.ADMIN) {
+      throw new UnitAccessDeniedException('remover');
+    }
+
+    const condominiumId = context.condominiumId as string;
+
+    const unit = await this.prisma.unit.findFirst({
+      where: { id, block: { condominiumId } },
+    });
+
+    if (!unit) {
+      throw new UnitNotFoundException(id);
+    }
+
+    const residentsCount = await this.prisma.resident.count({
+      where: { unitId: id },
+    });
+
+    if (residentsCount > 0) {
+      throw new UnitHasResidentsException(id);
+    }
+
+    await this.prisma.unit.delete({ where: { id } });
+
+    return { message: 'Unidade removida com sucesso.' };
+  }
+}

--- a/apps/api/swagger.json
+++ b/apps/api/swagger.json
@@ -1181,6 +1181,381 @@
           "announcements"
         ]
       }
+    },
+    "/api/v1/blocks": {
+      "get": {
+        "description": "Lista todos os blocos do condomínio ordenados por nome.",
+        "operationId": "BlocksController_findAll",
+        "parameters": [
+          {
+            "name": "page",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de blocos retornada com sucesso."
+          },
+          "401": {
+            "description": "Não autenticado."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Listar blocos do condomínio",
+        "tags": [
+          "blocks"
+        ]
+      },
+      "post": {
+        "operationId": "BlocksController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBlockDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Bloco criado com sucesso."
+          },
+          "409": {
+            "description": "Já existe bloco com este nome."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Criar bloco (Admin)",
+        "tags": [
+          "blocks"
+        ]
+      }
+    },
+    "/api/v1/blocks/{id}": {
+      "get": {
+        "operationId": "BlocksController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID do bloco",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bloco encontrado."
+          },
+          "404": {
+            "description": "Bloco não encontrado."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Buscar bloco pelo ID",
+        "tags": [
+          "blocks"
+        ]
+      },
+      "patch": {
+        "operationId": "BlocksController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID do bloco",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBlockDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bloco atualizado com sucesso."
+          },
+          "404": {
+            "description": "Bloco não encontrado."
+          },
+          "409": {
+            "description": "Já existe bloco com este nome."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Atualizar bloco (Admin)",
+        "tags": [
+          "blocks"
+        ]
+      },
+      "delete": {
+        "operationId": "BlocksController_delete",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID do bloco",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bloco removido com sucesso."
+          },
+          "404": {
+            "description": "Bloco não encontrado."
+          },
+          "409": {
+            "description": "Bloco possui unidades vinculadas."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Remover bloco (Admin)",
+        "tags": [
+          "blocks"
+        ]
+      }
+    },
+    "/api/v1/units": {
+      "get": {
+        "description": "Lista todas as unidades do condomínio ordenadas por número. Pode filtrar por bloco.",
+        "operationId": "UnitsController_findAll",
+        "parameters": [
+          {
+            "name": "page",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "blockId",
+            "required": false,
+            "in": "query",
+            "description": "Filtrar por UUID do bloco",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de unidades retornada com sucesso."
+          },
+          "401": {
+            "description": "Não autenticado."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Listar unidades do condomínio",
+        "tags": [
+          "units"
+        ]
+      },
+      "post": {
+        "operationId": "UnitsController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUnitDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Unidade criada com sucesso."
+          },
+          "409": {
+            "description": "Já existe unidade com este número."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Criar unidade (Admin)",
+        "tags": [
+          "units"
+        ]
+      }
+    },
+    "/api/v1/units/{id}": {
+      "get": {
+        "operationId": "UnitsController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID da unidade",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unidade encontrada."
+          },
+          "404": {
+            "description": "Unidade não encontrada."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Buscar unidade pelo ID",
+        "tags": [
+          "units"
+        ]
+      },
+      "patch": {
+        "operationId": "UnitsController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID da unidade",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUnitDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Unidade atualizada com sucesso."
+          },
+          "404": {
+            "description": "Unidade não encontrada."
+          },
+          "409": {
+            "description": "Já existe unidade com este número."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Atualizar unidade (Admin)",
+        "tags": [
+          "units"
+        ]
+      },
+      "delete": {
+        "operationId": "UnitsController_delete",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "UUID da unidade",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unidade removida com sucesso."
+          },
+          "404": {
+            "description": "Unidade não encontrada."
+          },
+          "409": {
+            "description": "Unidade possui moradores vinculados."
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Remover unidade (Admin)",
+        "tags": [
+          "units"
+        ]
+      }
     }
   },
   "info": {
@@ -1625,6 +2000,73 @@
           "title",
           "content"
         ]
+      },
+      "CreateBlockDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 50,
+            "example": "Bloco A",
+            "description": "Nome do bloco"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "UpdateBlockDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 50,
+            "example": "Bloco A - Atualizado",
+            "description": "Novo nome do bloco"
+          }
+        }
+      },
+      "CreateUnitDto": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "example": "101",
+            "description": "Número da unidade"
+          },
+          "blockId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "uuid-do-bloco",
+            "description": "UUID do bloco"
+          }
+        },
+        "required": [
+          "number",
+          "blockId"
+        ]
+      },
+      "UpdateUnitDto": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20,
+            "example": "102",
+            "description": "Novo número da unidade"
+          },
+          "blockId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "uuid-do-bloco",
+            "description": "UUID do bloco"
+          }
+        }
       }
     }
   }

--- a/apps/web/src/api/http.ts
+++ b/apps/web/src/api/http.ts
@@ -30,7 +30,10 @@ http.interceptors.response.use(
     async (error) => {
         finish();
         const config = error.config
-        if (!config || config._retryCount === undefined) {
+        if (!config) {
+            return Promise.reject(error)
+        }
+        if (config._retryCount === undefined) {
             config._retryCount = 0
         }
         const shouldRetry =

--- a/apps/web/src/modules/admin/routes.ts
+++ b/apps/web/src/modules/admin/routes.ts
@@ -11,6 +11,10 @@ import AvailabilityPage from '@/modules/resident/pages/AvailabilityPage.vue'
 import AnnouncementsPage from './pages/AnnouncementsPage.vue'
 import AccountSettingsPage from './pages/AccountSettingsPage.vue'
 import HelpPage from '@/modules/shared/pages/HelpPage.vue'
+import BlocksListPage from '@/modules/blocks/pages/BlocksListPage.vue'
+import BlocksFormPage from '@/modules/blocks/pages/BlocksFormPage.vue'
+import UnitsListPage from '@/modules/units/pages/UnitsListPage.vue'
+import UnitsFormPage from '@/modules/units/pages/UnitsFormPage.vue'
 
 export const adminRoutes = [
   {
@@ -37,6 +41,36 @@ export const adminRoutes = [
     path: '/condominium/residents/:id/edit',
     name: 'admin-residents-edit',
     component: ResidentsFormPage,
+  },
+  {
+    path: '/condominium/blocks',
+    name: 'admin-blocks',
+    component: BlocksListPage,
+  },
+  {
+    path: '/condominium/blocks/new',
+    name: 'admin-blocks-new',
+    component: BlocksFormPage,
+  },
+  {
+    path: '/condominium/blocks/:id/edit',
+    name: 'admin-blocks-edit',
+    component: BlocksFormPage,
+  },
+  {
+    path: '/condominium/units',
+    name: 'admin-units',
+    component: UnitsListPage,
+  },
+  {
+    path: '/condominium/units/new',
+    name: 'admin-units-new',
+    component: UnitsFormPage,
+  },
+  {
+    path: '/condominium/units/:id/edit',
+    name: 'admin-units-edit',
+    component: UnitsFormPage,
   },
   {
     path: '/condominium/reservations',

--- a/apps/web/src/modules/auth/pages/LoginPage.vue
+++ b/apps/web/src/modules/auth/pages/LoginPage.vue
@@ -38,7 +38,6 @@ import AuthSocialButtons from '../components/AuthSocialButtons.vue'
 import AuthDivider from '../components/AuthDivider.vue'
 import AuthSupportCards from '../components/AuthSupportCards.vue'
 import LoginForm from '../components/LoginForm.vue'
-import { loginRequest } from '../auth.api'
 import { authService } from '../services/auth.service'
 import { useToast } from '@/modules/shared/composables/useToast'
 
@@ -65,10 +64,7 @@ const handleLogin = async (credentials: { email: string; password: string }) => 
   error.value = ''
   
   try {
-    const response = await loginRequest(credentials)
-    localStorage.setItem('auth_token', response.accessToken)
-    localStorage.setItem('auth_user', JSON.stringify(response.user))
-    localStorage.setItem('auth_condo', JSON.stringify(response.condominium))
+    const response = await authService.login(credentials)
     toastSuccess(response.message)
     const redirectPath = response.user.role === 'ADMIN'
       ? '/condominium/dashboard'

--- a/apps/web/src/modules/blocks/pages/BlocksFormPage.vue
+++ b/apps/web/src/modules/blocks/pages/BlocksFormPage.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="flex min-h-screen bg-surface text-on-surface">
+    <SideNavBar role="ADMIN" :userName="userName" :collapsed="sidebarCollapsed" @toggle-collapse="toggleCollapse" @logout="handleLogout" @cta-click="handleQuickAction" :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" />
+
+    <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
+      <TopAppBar :userName="userName" userRole="ADMIN" @toggle-sidebar="sidebarOpen = !sidebarOpen" />
+
+      <div class="flex-1 p-4 md:p-6 lg:p-8 space-y-4 md:space-y-6 lg:space-y-8 w-full max-w-2xl">
+        <div>
+          <h2 class="text-2xl md:text-3xl font-extrabold text-primary tracking-tight font-headline">{{ isEdit ? 'Editar Bloco' : 'Novo Bloco' }}</h2>
+          <p class="text-on-surface-variant mt-1 md:mt-2 text-sm md:text-base">{{ isEdit ? 'Atualize as informações do bloco' : 'Cadastre um novo bloco no condomínio' }}</p>
+        </div>
+
+        <form @submit.prevent="handleSubmit" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1.5">Nome do Bloco</label>
+            <input v-model="form.name" type="text" class="w-full px-4 py-3 bg-surface-container-low border-none rounded-xl text-sm" placeholder="Ex: Bloco A" required />
+            <p v-if="errors.name" class="text-error text-xs mt-1">{{ errors.name }}</p>
+          </div>
+
+          <div class="flex items-center gap-3 pt-2">
+            <button type="submit" class="px-6 py-3 bg-primary text-white rounded-xl font-medium hover:opacity-90 transition-opacity text-sm" :disabled="saving">
+              {{ saving ? 'Salvando...' : (isEdit ? 'Atualizar' : 'Criar Bloco') }}
+            </button>
+            <router-link to="/condominium/blocks" class="px-6 py-3 border border-slate-200 rounded-xl text-slate-600 hover:bg-slate-50 transition-colors text-sm">Cancelar</router-link>
+          </div>
+        </form>
+      </div>
+    </main>
+
+    <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
+import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
+import { authService } from '@/modules/auth/services/auth.service'
+import { blocksService } from '../services/blocks.service'
+import { http } from '@/api/http'
+import { useToast } from '@/modules/shared/composables/useToast'
+import { useApiError } from '@/modules/shared/composables/useApiError'
+import { useSidebar } from '@/modules/shared/composables/useSidebar'
+
+const router = useRouter()
+const route = useRoute()
+const { success: showSuccess } = useToast()
+const { handleError } = useApiError()
+
+const user = authService.getUser()
+const userName = ref(user?.name || '')
+const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
+
+const isEdit = computed(() => !!route.params.id)
+const saving = ref(false)
+const form = ref({ name: '' })
+const errors = ref<Record<string, string>>({})
+
+onMounted(async () => {
+  if (isEdit.value) {
+    try {
+      const block = await blocksService.getById(route.params.id as string)
+      form.value.name = block.name
+    } catch (err) {
+      handleError(err, 'Erro ao carregar bloco')
+    }
+  }
+})
+
+const handleSubmit = async () => {
+  errors.value = {}
+  if (!form.value.name.trim()) {
+    errors.value.name = 'O nome é obrigatório'
+    return
+  }
+
+  saving.value = true
+  try {
+    if (isEdit.value) {
+      await blocksService.update(route.params.id as string, { name: form.value.name.trim() })
+      showSuccess('Bloco atualizado com sucesso')
+    } else {
+      await blocksService.create({ name: form.value.name.trim() })
+      showSuccess('Bloco criado com sucesso')
+    }
+    router.push('/condominium/blocks')
+  } catch (err) {
+    handleError(err, `Erro ao ${isEdit.value ? 'atualizar' : 'criar'} bloco`)
+  } finally {
+    saving.value = false
+  }
+}
+
+const handleQuickAction = () => {
+  router.push('/condominium/blocks/new')
+}
+
+const handleLogout = async () => {
+  try { await http.post('/auth/logout') } catch {}
+  authService.logout()
+  router.push('/')
+}
+</script>
+
+<style scoped>
+.font-headline { font-family: 'Manrope', sans-serif; }
+.material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+</style>

--- a/apps/web/src/modules/blocks/pages/BlocksListPage.vue
+++ b/apps/web/src/modules/blocks/pages/BlocksListPage.vue
@@ -1,0 +1,161 @@
+<template>
+  <div class="flex min-h-screen bg-surface text-on-surface">
+    <SideNavBar role="ADMIN" :userName="userName" :collapsed="sidebarCollapsed" @toggle-collapse="toggleCollapse" @logout="handleLogout" @cta-click="handleQuickAction" :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" />
+
+    <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
+      <TopAppBar :userName="userName" userRole="ADMIN" @toggle-sidebar="sidebarOpen = !sidebarOpen" />
+
+      <div class="flex-1 p-4 md:p-6 lg:p-8 space-y-4 md:space-y-6 lg:space-y-8 w-full max-w-full">
+        <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <h2 class="text-2xl md:text-3xl font-extrabold text-primary tracking-tight font-headline">Blocos</h2>
+            <p class="text-on-surface-variant mt-1 md:mt-2 text-sm md:text-base">Gerencie os blocos do condomínio</p>
+          </div>
+          <router-link to="/condominium/blocks/new" class="w-full sm:w-auto px-4 md:px-6 py-2.5 md:py-3 bg-primary text-white rounded-xl font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2 text-sm md:text-base">
+            <span class="material-symbols-outlined text-lg">add</span>
+            <span>Novo Bloco</span>
+          </router-link>
+        </div>
+
+        <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl overflow-hidden shadow-sm">
+          <div class="overflow-x-auto">
+            <table class="w-full">
+              <thead class="bg-surface-container-low">
+                <tr>
+                  <th class="text-left px-4 md:px-6 py-4 text-sm font-semibold text-slate-600">Nome</th>
+                  <th class="text-left px-4 md:px-6 py-4 text-sm font-semibold text-slate-600">Ações</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100">
+                <tr v-for="block in blocks" :key="block.id" class="hover:bg-white transition-colors">
+                  <td class="px-4 md:px-6 py-4">
+                    <p class="font-semibold text-cyan-900 text-sm md:text-base">{{ block.name }}</p>
+                  </td>
+                  <td class="px-4 md:px-6 py-4">
+                    <div class="flex items-center gap-1 md:gap-2">
+                      <router-link :to="`/condominium/blocks/${block.id}/edit`" class="p-2 text-slate-400 hover:text-primary transition-colors" title="Editar">
+                        <span class="material-symbols-outlined">edit</span>
+                      </router-link>
+                      <button @click="confirmDelete(block)" class="p-2 text-slate-400 hover:text-error transition-colors" title="Remover">
+                        <span class="material-symbols-outlined">delete</span>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+                <tr v-if="blocks.length === 0">
+                  <td colspan="2" class="px-4 md:px-6 py-8 text-center text-slate-400">Nenhum bloco encontrado</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <Pagination :current="page" :total-pages="totalPages" @page="goToPage" />
+      </div>
+    </main>
+
+    <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
+
+    <div v-if="showDeleteModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div class="bg-white rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+        <h3 class="text-xl font-bold text-cyan-900 mb-2">Confirmar Remoção</h3>
+        <p class="text-slate-600 mb-6">
+          Tem certeza que deseja remover o bloco <strong>{{ deletingBlock?.name }}</strong>?
+        </p>
+        <div class="flex gap-3">
+          <button @click="showDeleteModal = false" class="flex-1 px-4 py-3 border border-slate-200 rounded-xl text-slate-600 hover:bg-slate-50 transition-colors">Cancelar</button>
+          <button @click="handleDelete" class="flex-1 px-4 py-3 bg-error text-white rounded-xl hover:bg-error/90 transition-colors">Remover</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
+import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
+import Pagination from '@/modules/shared/components/Pagination.vue'
+import { authService } from '@/modules/auth/services/auth.service'
+import { blocksService } from '../services/blocks.service'
+import { http } from '@/api/http'
+import { useToast } from '@/modules/shared/composables/useToast'
+import { useApiError } from '@/modules/shared/composables/useApiError'
+import { useSidebar } from '@/modules/shared/composables/useSidebar'
+
+const router = useRouter()
+const { error: showError, success: showSuccess } = useToast()
+const { handleError } = useApiError()
+
+const user = authService.getUser()
+const userName = ref(user?.name || '')
+
+interface BlockItem {
+  id: string
+  name: string
+}
+
+const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
+const blocks = ref<BlockItem[]>([])
+const loading = ref(false)
+const showDeleteModal = ref(false)
+const deletingBlock = ref<BlockItem | null>(null)
+const page = ref(1)
+const totalPages = ref(1)
+
+async function goToPage(p: number) {
+  page.value = p
+  await fetchBlocks()
+}
+
+const fetchBlocks = async () => {
+  try {
+    loading.value = true
+    const data = await blocksService.getAll(page.value, 10)
+    blocks.value = data.blocks || []
+    totalPages.value = data.totalPages
+  } catch (err) {
+    handleError(err, 'Erro ao carregar blocos')
+  } finally {
+    loading.value = false
+  }
+}
+
+const confirmDelete = (block: BlockItem) => {
+  deletingBlock.value = block
+  showDeleteModal.value = true
+}
+
+const handleDelete = async () => {
+  if (!deletingBlock.value) return
+  try {
+    await blocksService.delete(deletingBlock.value.id)
+    showSuccess('Bloco removido com sucesso')
+    showDeleteModal.value = false
+    deletingBlock.value = null
+    await fetchBlocks()
+  } catch (err) {
+    handleError(err, 'Erro ao remover bloco')
+  }
+}
+
+const handleQuickAction = () => {
+  router.push('/condominium/blocks/new')
+}
+
+const handleLogout = async () => {
+  try { await http.post('/auth/logout') } catch {}
+  authService.logout()
+  router.push('/')
+}
+
+onMounted(() => {
+  fetchBlocks()
+})
+</script>
+
+<style scoped>
+.font-headline { font-family: 'Manrope', sans-serif; }
+.material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+</style>

--- a/apps/web/src/modules/blocks/services/blocks.service.ts
+++ b/apps/web/src/modules/blocks/services/blocks.service.ts
@@ -1,0 +1,44 @@
+import { http } from '@/api/http'
+
+export interface Block {
+  id: string
+  name: string
+  condominiumId: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface BlockListOutput {
+  blocks: Block[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+export const blocksService = {
+  async getAll(page = 1, limit = 10): Promise<BlockListOutput> {
+    const response = await http.get('/blocks', { params: { page, limit } })
+    return response.data.data
+  },
+
+  async getById(id: string): Promise<Block> {
+    const response = await http.get(`/blocks/${id}`)
+    return response.data.data
+  },
+
+  async create(data: { name: string }): Promise<Block> {
+    const response = await http.post('/blocks', data)
+    return response.data.data
+  },
+
+  async update(id: string, data: { name?: string }): Promise<Block> {
+    const response = await http.patch(`/blocks/${id}`, data)
+    return response.data.data
+  },
+
+  async delete(id: string): Promise<{ message: string }> {
+    const response = await http.delete(`/blocks/${id}`)
+    return response.data.data
+  },
+}

--- a/apps/web/src/modules/shared/components/SideNavBar.spec.ts
+++ b/apps/web/src/modules/shared/components/SideNavBar.spec.ts
@@ -38,15 +38,17 @@ describe('SideNavBar', () => {
     })
 
     const links = wrapper.findAll('nav a')
-    expect(links.length).toBe(8)
+    expect(links.length).toBe(10)
     expect(links.at(0)?.text()).toContain('Início')
     expect(links.at(1)?.text()).toContain('Condomínio')
     expect(links.at(2)?.text()).toContain('Moradores')
-    expect(links.at(3)?.text()).toContain('Áreas Comuns')
-    expect(links.at(4)?.text()).toContain('Reservas')
-    expect(links.at(5)?.text()).toContain('Disponibilidade')
-    expect(links.at(6)?.text()).toContain('Comunicados')
-    expect(links.at(7)?.text()).toContain('Relatórios')
+    expect(links.at(3)?.text()).toContain('Blocos')
+    expect(links.at(4)?.text()).toContain('Unidades')
+    expect(links.at(5)?.text()).toContain('Áreas Comuns')
+    expect(links.at(6)?.text()).toContain('Reservas')
+    expect(links.at(7)?.text()).toContain('Disponibilidade')
+    expect(links.at(8)?.text()).toContain('Comunicados')
+    expect(links.at(9)?.text()).toContain('Relatórios')
   })
 
   it('should render resident menu items', () => {

--- a/apps/web/src/modules/shared/config/menuConfig.ts
+++ b/apps/web/src/modules/shared/config/menuConfig.ts
@@ -17,6 +17,8 @@ export const menuConfig: Record<UserRole, MenuItem[]> = {
     { path: '/condominium/dashboard', label: 'Início', icon: 'dashboard' },
     { path: '/condominium/settings', label: 'Condomínio', icon: 'apartment' },
     { path: '/condominium/residents', label: 'Moradores', icon: 'group' },
+    { path: '/condominium/blocks', label: 'Blocos', icon: 'layers' },
+    { path: '/condominium/units', label: 'Unidades', icon: 'door_front' },
     { path: '/condominium/common-areas', label: 'Áreas Comuns', icon: 'pool' },
     { path: '/condominium/reservations', label: 'Reservas', icon: 'event_available' },
     { path: '/condominium/availability', label: 'Disponibilidade', icon: 'calendar_month' },

--- a/apps/web/src/modules/units/pages/UnitsFormPage.vue
+++ b/apps/web/src/modules/units/pages/UnitsFormPage.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="flex min-h-screen bg-surface text-on-surface">
+    <SideNavBar role="ADMIN" :userName="userName" :collapsed="sidebarCollapsed" @toggle-collapse="toggleCollapse" @logout="handleLogout" @cta-click="handleQuickAction" :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" />
+
+    <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
+      <TopAppBar :userName="userName" userRole="ADMIN" @toggle-sidebar="sidebarOpen = !sidebarOpen" />
+
+      <div class="flex-1 p-4 md:p-6 lg:p-8 space-y-4 md:space-y-6 lg:space-y-8 w-full max-w-2xl">
+        <div>
+          <h2 class="text-2xl md:text-3xl font-extrabold text-primary tracking-tight font-headline">{{ isEdit ? 'Editar Unidade' : 'Nova Unidade' }}</h2>
+          <p class="text-on-surface-variant mt-1 md:mt-2 text-sm md:text-base">{{ isEdit ? 'Atualize as informações da unidade' : 'Cadastre uma nova unidade no condomínio' }}</p>
+        </div>
+
+        <form @submit.prevent="handleSubmit" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1.5">Número da Unidade</label>
+            <input v-model="form.number" type="text" class="w-full px-4 py-3 bg-surface-container-low border-none rounded-xl text-sm" placeholder="Ex: 101" required />
+            <p v-if="errors.number" class="text-error text-xs mt-1">{{ errors.number }}</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 mb-1.5">Bloco</label>
+            <select v-model="form.blockId" class="w-full px-4 py-3 bg-surface-container-low border-none rounded-xl text-sm" :required="!isEdit">
+              <option value="" disabled>Selecione um bloco</option>
+              <option v-for="block in blocks" :key="block.id" :value="block.id">{{ block.name }}</option>
+            </select>
+            <p v-if="errors.blockId" class="text-error text-xs mt-1">{{ errors.blockId }}</p>
+          </div>
+
+          <div class="flex items-center gap-3 pt-2">
+            <button type="submit" class="px-6 py-3 bg-primary text-white rounded-xl font-medium hover:opacity-90 transition-opacity text-sm" :disabled="saving">
+              {{ saving ? 'Salvando...' : (isEdit ? 'Atualizar' : 'Criar Unidade') }}
+            </button>
+            <router-link to="/condominium/units" class="px-6 py-3 border border-slate-200 rounded-xl text-slate-600 hover:bg-slate-50 transition-colors text-sm">Cancelar</router-link>
+          </div>
+        </form>
+      </div>
+    </main>
+
+    <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
+import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
+import { authService } from '@/modules/auth/services/auth.service'
+import { blocksService } from '@/modules/blocks/services/blocks.service'
+import { unitsService } from '../services/units.service'
+import { http } from '@/api/http'
+import { useToast } from '@/modules/shared/composables/useToast'
+import { useApiError } from '@/modules/shared/composables/useApiError'
+import { useSidebar } from '@/modules/shared/composables/useSidebar'
+
+const router = useRouter()
+const route = useRoute()
+const { success: showSuccess } = useToast()
+const { handleError } = useApiError()
+
+const user = authService.getUser()
+const userName = ref(user?.name || '')
+const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
+
+const isEdit = computed(() => !!route.params.id)
+const saving = ref(false)
+const blocks = ref<{ id: string; name: string }[]>([])
+const form = ref({ number: '', blockId: '' })
+const errors = ref<Record<string, string>>({})
+
+onMounted(async () => {
+  try {
+    const data = await blocksService.getAll(1, 100)
+    blocks.value = data.blocks || []
+  } catch {}
+
+  if (isEdit.value) {
+    try {
+      const unit = await unitsService.getById(route.params.id as string)
+      form.value.number = unit.number
+      form.value.blockId = unit.blockId
+    } catch (err) {
+      handleError(err, 'Erro ao carregar unidade')
+    }
+  }
+})
+
+const handleSubmit = async () => {
+  errors.value = {}
+  if (!form.value.number.trim()) {
+    errors.value.number = 'O número é obrigatório'
+    return
+  }
+  if (!isEdit.value && !form.value.blockId) {
+    errors.value.blockId = 'O bloco é obrigatório'
+    return
+  }
+
+  saving.value = true
+  try {
+    if (isEdit.value) {
+      await unitsService.update(route.params.id as string, {
+        number: form.value.number.trim(),
+        ...(form.value.blockId ? { blockId: form.value.blockId } : {}),
+      })
+      showSuccess('Unidade atualizada com sucesso')
+    } else {
+      await unitsService.create({ number: form.value.number.trim(), blockId: form.value.blockId })
+      showSuccess('Unidade criada com sucesso')
+    }
+    router.push('/condominium/units')
+  } catch (err) {
+    handleError(err, `Erro ao ${isEdit.value ? 'atualizar' : 'criar'} unidade`)
+  } finally {
+    saving.value = false
+  }
+}
+
+const handleQuickAction = () => {
+  router.push('/condominium/units/new')
+}
+
+const handleLogout = async () => {
+  try { await http.post('/auth/logout') } catch {}
+  authService.logout()
+  router.push('/')
+}
+</script>
+
+<style scoped>
+.font-headline { font-family: 'Manrope', sans-serif; }
+.material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+</style>

--- a/apps/web/src/modules/units/pages/UnitsListPage.vue
+++ b/apps/web/src/modules/units/pages/UnitsListPage.vue
@@ -1,0 +1,193 @@
+<template>
+  <div class="flex min-h-screen bg-surface text-on-surface">
+    <SideNavBar role="ADMIN" :userName="userName" :collapsed="sidebarCollapsed" @toggle-collapse="toggleCollapse" @logout="handleLogout" @cta-click="handleQuickAction" :class="['transition-transform duration-300', sidebarOpen ? 'translate-x-0' : '-translate-x-full', 'fixed z-50', 'md:translate-x-0']" />
+
+    <main :class="['flex-1 flex flex-col min-h-screen w-full transition-all duration-300', sidebarCollapsed ? 'md:ml-16' : 'md:ml-72']">
+      <TopAppBar :userName="userName" userRole="ADMIN" @toggle-sidebar="sidebarOpen = !sidebarOpen" />
+
+      <div class="flex-1 p-4 md:p-6 lg:p-8 space-y-4 md:space-y-6 lg:space-y-8 w-full max-w-full">
+        <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <h2 class="text-2xl md:text-3xl font-extrabold text-primary tracking-tight font-headline">Unidades</h2>
+            <p class="text-on-surface-variant mt-1 md:mt-2 text-sm md:text-base">Gerencie as unidades do condomínio</p>
+          </div>
+          <router-link to="/condominium/units/new" class="w-full sm:w-auto px-4 md:px-6 py-2.5 md:py-3 bg-primary text-white rounded-xl font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2 text-sm md:text-base">
+            <span class="material-symbols-outlined text-lg">add</span>
+            <span>Nova Unidade</span>
+          </router-link>
+        </div>
+
+        <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3 md:gap-4">
+          <select v-model="filterBlockId" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 bg-surface-container-low border-none rounded-xl text-sm md:text-base" style="padding-right: 2.5rem;">
+            <option value="">Todos os blocos</option>
+            <option v-for="block in blocks" :key="block.id" :value="block.id">{{ block.name }}</option>
+          </select>
+        </div>
+
+        <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl overflow-hidden shadow-sm">
+          <div class="overflow-x-auto">
+            <table class="w-full">
+              <thead class="bg-surface-container-low">
+                <tr>
+                  <th class="text-left px-4 md:px-6 py-4 text-sm font-semibold text-slate-600">Número</th>
+                  <th class="text-left px-4 md:px-6 py-4 text-sm font-semibold text-slate-600">Bloco</th>
+                  <th class="text-left px-4 md:px-6 py-4 text-sm font-semibold text-slate-600">Ações</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100">
+                <tr v-for="unit in units" :key="unit.id" class="hover:bg-white transition-colors">
+                  <td class="px-4 md:px-6 py-4">
+                    <p class="font-semibold text-cyan-900 text-sm md:text-base">{{ unit.number }}</p>
+                  </td>
+                  <td class="px-4 md:px-6 py-4 text-slate-600 text-sm md:text-base">{{ unit.blockName || '—' }}</td>
+                  <td class="px-4 md:px-6 py-4">
+                    <div class="flex items-center gap-1 md:gap-2">
+                      <router-link :to="`/condominium/units/${unit.id}/edit`" class="p-2 text-slate-400 hover:text-primary transition-colors" title="Editar">
+                        <span class="material-symbols-outlined">edit</span>
+                      </router-link>
+                      <button @click="confirmDelete(unit)" class="p-2 text-slate-400 hover:text-error transition-colors" title="Remover">
+                        <span class="material-symbols-outlined">delete</span>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+                <tr v-if="units.length === 0">
+                  <td colspan="3" class="px-4 md:px-6 py-8 text-center text-slate-400">Nenhuma unidade encontrada</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <Pagination :current="page" :total-pages="totalPages" @page="goToPage" />
+      </div>
+    </main>
+
+    <div v-if="sidebarOpen" class="fixed inset-0 bg-black/50 z-40 md:hidden" @click="sidebarOpen = false"></div>
+
+    <div v-if="showDeleteModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div class="bg-white rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+        <h3 class="text-xl font-bold text-cyan-900 mb-2">Confirmar Remoção</h3>
+        <p class="text-slate-600 mb-6">
+          Tem certeza que deseja remover a unidade <strong>{{ deletingUnit?.number }}</strong>?
+        </p>
+        <div class="flex gap-3">
+          <button @click="showDeleteModal = false" class="flex-1 px-4 py-3 border border-slate-200 rounded-xl text-slate-600 hover:bg-slate-50 transition-colors">Cancelar</button>
+          <button @click="handleDelete" class="flex-1 px-4 py-3 bg-error text-white rounded-xl hover:bg-error/90 transition-colors">Remover</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import SideNavBar from '@/modules/shared/components/SideNavBar.vue'
+import TopAppBar from '@/modules/shared/components/TopAppBar.vue'
+import Pagination from '@/modules/shared/components/Pagination.vue'
+import { authService } from '@/modules/auth/services/auth.service'
+import { blocksService } from '@/modules/blocks/services/blocks.service'
+import { unitsService } from '../services/units.service'
+import { http } from '@/api/http'
+import { useToast } from '@/modules/shared/composables/useToast'
+import { useApiError } from '@/modules/shared/composables/useApiError'
+import { useSidebar } from '@/modules/shared/composables/useSidebar'
+
+const router = useRouter()
+const { error: showError, success: showSuccess } = useToast()
+const { handleError } = useApiError()
+
+const user = authService.getUser()
+const userName = ref(user?.name || '')
+
+interface UnitItem {
+  id: string
+  number: string
+  blockId: string
+  blockName?: string
+}
+
+interface BlockItem {
+  id: string
+  name: string
+}
+
+const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
+const units = ref<UnitItem[]>([])
+const blocks = ref<BlockItem[]>([])
+const loading = ref(false)
+const showDeleteModal = ref(false)
+const deletingUnit = ref<UnitItem | null>(null)
+const page = ref(1)
+const totalPages = ref(1)
+const filterBlockId = ref('')
+
+watch(filterBlockId, () => {
+  page.value = 1
+  fetchUnits()
+})
+
+async function goToPage(p: number) {
+  page.value = p
+  await fetchUnits()
+}
+
+const fetchBlocks = async () => {
+  try {
+    const data = await blocksService.getAll(1, 100)
+    blocks.value = data.blocks || []
+  } catch {}
+}
+
+const fetchUnits = async () => {
+  try {
+    loading.value = true
+    const data = await unitsService.getAll(page.value, 10, filterBlockId.value || undefined)
+    units.value = data.units || []
+    totalPages.value = data.totalPages
+  } catch (err) {
+    handleError(err, 'Erro ao carregar unidades')
+  } finally {
+    loading.value = false
+  }
+}
+
+const confirmDelete = (unit: UnitItem) => {
+  deletingUnit.value = unit
+  showDeleteModal.value = true
+}
+
+const handleDelete = async () => {
+  if (!deletingUnit.value) return
+  try {
+    await unitsService.delete(deletingUnit.value.id)
+    showSuccess('Unidade removida com sucesso')
+    showDeleteModal.value = false
+    deletingUnit.value = null
+    await fetchUnits()
+  } catch (err) {
+    handleError(err, 'Erro ao remover unidade')
+  }
+}
+
+const handleQuickAction = () => {
+  router.push('/condominium/units/new')
+}
+
+const handleLogout = async () => {
+  try { await http.post('/auth/logout') } catch {}
+  authService.logout()
+  router.push('/')
+}
+
+onMounted(() => {
+  fetchBlocks()
+  fetchUnits()
+})
+</script>
+
+<style scoped>
+.font-headline { font-family: 'Manrope', sans-serif; }
+.material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+</style>

--- a/apps/web/src/modules/units/services/units.service.ts
+++ b/apps/web/src/modules/units/services/units.service.ts
@@ -1,0 +1,47 @@
+import { http } from '@/api/http'
+
+export interface Unit {
+  id: string
+  number: string
+  blockId: string
+  blockName?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UnitListOutput {
+  units: Unit[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+}
+
+export const unitsService = {
+  async getAll(page = 1, limit = 10, blockId?: string): Promise<UnitListOutput> {
+    const params: Record<string, unknown> = { page, limit }
+    if (blockId) params.blockId = blockId
+    const response = await http.get('/units', { params })
+    return response.data.data
+  },
+
+  async getById(id: string): Promise<Unit> {
+    const response = await http.get(`/units/${id}`)
+    return response.data.data
+  },
+
+  async create(data: { number: string; blockId: string }): Promise<Unit> {
+    const response = await http.post('/units', data)
+    return response.data.data
+  },
+
+  async update(id: string, data: { number?: string; blockId?: string }): Promise<Unit> {
+    const response = await http.patch(`/units/${id}`, data)
+    return response.data.data
+  },
+
+  async delete(id: string): Promise<{ message: string }> {
+    const response = await http.delete(`/units/${id}`)
+    return response.data.data
+  },
+}


### PR DESCRIPTION
* Chore/ajustes gerais (#52)

* fix: configs

* ajuste: route login

* Chore: .env.example

* fix: ajustes de responsividade para dispositivos móveis

- Remove hidden sm:block do sino de notificação (TopAppBar)
- Torna botão 'Novo Comunicado' visível em mobile (AnnouncementsPage)
- Adiciona layout de cards mobile na página de Reservas
- Adiciona layout de cards mobile na página de Relatórios
- Torna padding do LandingHeader responsivo (px-6 md:px-10)
- Corrige overflow das abas em AccountSettings e Settings (w-full md:w-fit)

* docs: sincroniza PRD e SDD com a implementação real + corrige documentação Swagger

- SDD: adiciona entidade Announcement, corrige unitId (opcional), atualiza CreateReservationDTO (date+startTime/endTime), adiciona endpoints faltantes (auth/me, change-password, permissions, announcements), marca Block/Unit como dados apenas (sem REST)
- PRD: adiciona Comunicados como user story
- API: ativa plugin @nestjs/swagger com classValidatorShim, adiciona @ApiPropertyOptional no UpdateCondominiumDto, corrige logout (JwtAuthGuard), atualiza descrição/tags no Swagger
- Regenera swagger.json

* feat: prepara código para rodar em qualquer PostgreSQL (local ou produção)

- CORS lê de CORS_ORIGIN (env var) com fallback localhost
- Web usa VITE_API_URL (env var) com fallback localhost
- dotenv condicional: só carrega .env se arquivo existir
- Extrai bootstrap-app.ts compartilhado (main.ts + vercel-handler.ts)
- Cria vercel-handler.ts para deploy serverless no Vercel
- Cria vercel.json para API (serverless) e Web (SPA)
- Adiciona script vercel-build com prisma generate
- Remove menção específica a Neon.tech no Swagger
- Atualiza .env.example com CORS_ORIGIN e VITE_API_URL

* refactor: simplifica deploy usando zero-config NestJS do Vercel

Remove vercel-handler.ts e serverless-http: Vercel detecta automaticamente NestJS via src/main.ts (zero-config).

Remove bootstrap-app.ts (main.ts volta a ser arquivo único).

Remove apps/api/vercel.json: sem necessidade com zero-config.

Adiciona postinstall prisma generate para garantir cliente atualizado no build do Vercel (recomendação oficial Prisma).

Mantém apps/web/vercel.json (necessário para SPA rewrites).

* fix: corrige 36 type errors no frontend (vue-tsc strict)

- UserRole: adiciona import + type assertion nos componentes
- operatingDays: adiciona 'string' na união de tipos (faltava)
- h/m destructuring: adiciona fallback ?? 0 para possibly undefined
- statusLabel: aceita string | undefined e faz guard antes do map
- DAYS_MAP[v]!: non-null assertion no spread do Record
- getDateStr: fallback ?? '' no split
- Test mocks: adiciona campos faltantes (role, isActive, createdAt, temporaryPassword, page, limit, totalPages, phone omitido)
- Test DOM: non-null assertion em wrapper.findAll()[0]!
- Mantém apps/web/vercel.json (SPA rewrites)

* fix: update middleware forRoutes pattern

* feat: deploy Vercel com API serverless e frontend Vue

* fix: add Swagger docs to Vercel serverless handler

* fix: serve Swagger UI with CDN assets on Vercel

* chore: readme.md

* fix: add DATABASE_URL to npm ci step in CI

* feat: add Vercel auto-deploy workflow on push to develop

* chore: remove vercel link step from deploy workflow (uses env vars)

* fix: change deploy trigger from develop to main

* fix: remove postinstall (prisma generate) - breaks Vercel build without DATABASE_URL

* fix: restore api/index.ts, add express types, fix Vercel build, install serverless-http

* fix: remove serverless-http and handler from main.ts (api/index.ts handles Vercel)

---------




* Main to Develop (#55)

* Develop to Main (#34)

* Init: develop

* Test: SDD

* Fix: PRD and SSD Markdown

* Update checklist.md

* Merge pull request #16 from lucasgfaj/@lucasgfaj-create-dirs-and-tools

[Setup] Integração estrutural de Apps (Nest, Vue) e Docs

* Feature/15 import neon db and prisma orm (#17)

* Add Prisma and Neon

* chore: configure Prisma and update tech stack in documentation

- Install missing dependencies via npm i (package-lock.json) for Prisma local validation

- Update docs/ssd.md injecting exact package versions (NestJS v11, Prisma v7.6, Neon Postgres v16, Vue v3.5)

- Sync tech stack declarations inside docs/prd.md to match SSD versions

* feat: implement database schema and migrations for issue #15

---------



* feat: add docker-compose for local development and .env.example (#18)



* Feature/setup workspaces (#19)

* chore: configura monorepo com npm workspaces na raiz

* fix

---------



* ci: adiciona gatilho de push e badge de status no readme (#20)

* ci: adiciona gatilho de push e badge de status no readme

* fix: package

---------



* Feature/ci push and badge (#21)

* ci: adiciona gatilho de push e badges de status no readme

* docs: status do sistema

---------



* feat: Landing Page Modularization and Auth Layout (#23)

* web: inicio de diretorios

* feat: landing page implementation and web auth layout

* chore: package-lock.json fix

* fix: erro tailwind

---------



* Feature/us01 self service onboarding (#24)

* feat(api): implement US01 self-service onboarding and prisma 7 setup

- implement unified registration for Condominium and Admin User (US01)
- configure Prisma 7 with @prisma/adapter-pg for stable PostgreSQL connection
- setup global API prefix /api/v1 and validation pipes
- fix environment variables loading for monorepo environment
- add ACID transactions for tenant onboarding

* docs(api): setup Swagger UI and API welcome portal

- install and configure @nestjs/swagger
- document register endpoint with detailed examples and cURL commands
- enhance AppController with API metadata and health info
- polish Swagger UI description with PRD/SSD alignment

* feat(web): add self-service onboarding with login and register pages

* test(api): add unit tests for auth module following TDD

- Add AuthService unit tests (registerTenant, email conflict, JWT token)
- Add AuthController unit tests (register endpoint)
- Add E2E test skeleton for auth integration
- Fix AppController test to match actual implementation

* test(api): add unit and E2E tests with real database

- Add unit tests for AppController, AppService, PrismaService following TDD
- Improve password validation (min 8 chars, letter, number, special char)
- Add E2E tests with real database and cleanup after tests
- Create prisma.config.ts (required for Prisma 7)
- Update docker-compose.yml to use reserva_ai_db
- Add dev:api:test:e2e script to root package.json
- Update CI to run both unit and E2E tests with isolated test database

* refactor(auth): apply clean code with interfaces and separated validator

- Add explicit interfaces (RegisterTenantInput, RegisterTenantOutput, AuthPayload)
- Extract validation to RegisterTenantValidator class
- Update service to use validator and interfaces
- Update tests to match new contract (accessToken instead of access_token)
- Add validator unit tests (14 cases)
- Add dev:prisma script to root package.json

* feat(auth+web): connect frontend to backend with auth service

Backend:
- Add CORS configuration in main.ts
- Update auth controller to use explicit interfaces

Frontend:
- Create auth service with DTOs (RegisterTenantDTO, LoginDTO)
- Centralize auth logic (login, logout, token storage)
- Add Vitest for web unit tests
- Fix RegisterPage to use authService
- Fix LoginPage handler bug
- Update http interceptor for auth_token key

Scripts:
- Add dev:prisma:studio to package.json
- Add dev:web:test and dev:web:test:watch

* fix: ci/cd

---------




* feature/3/us02 gerenciar dados do condomínio (#25)

* feat(auth): implementa login US02 com TDD e validação

- Adiciona endpoint POST /auth/login
- Cria LoginValidator com validação de email/senha (SOLID)
- Adiciona LoginDto e interfaces LoginInput/LoginOutput
- Implementa método login() no AuthService com validação
- Adiciona testes unitários para login (4 testes)
- Adiciona testes E2E para login (5 cenários)
- Segue padrões DDD com validador separado

* fix: erros

* fix(auth): traduz msgs de erro para pt-BR e adiciona message nos endpoints

- Traduz ConflictException 'User already exists' para 'Usuário com este email já existe'
- Adiciona campo 'message' nas responses de register e login
- Atualiza exemplos no swagger com senha contendo caractere especial
- Traduz mensagens de validação do login validator para pt-BR

* fix: corrige lint errors e atualiza testes com message field

- Adiciona .catch no bootstrap() do main.ts
- Atualiza mocks com campo 'message' em auth.controller.spec.ts
- Remove variáveis não utilizadas em auth.service.spec.ts
- Atualiza e2e testes com message field
- Adiciona isexe como dependência

* fix: corrige todos lint errors com tipagem adequada

- Remove interfaces não utilizadas em auth.service.spec.ts
- Tipa mocks com tipos concretos em vez de any
- Adiciona ignore unbound-method nos testes de controller
- Tipa parâmetros res em e2e tests

* fix: corrige todos lint warnings com disable para supertest

- Tipa res em app.e2e-spec.ts
- Adiciona eslint-disable para supertest no-auth e app e2e

* fix(auth): implementa login real no frontend

- Corrige auth.api.ts para tipos corretos da API
- Implementa handleLogin chamando API real
- Salva token e dados no localStorage

* fix(auth): redireciona para dashboard se logado e exibe messages

- Adiciona router guard para redirect /login /register / para dashboard
- Exibe message de sucesso via alert apos login/register
- Exibe message de erro via alert
- Atualiza interfaces com message field

* feat(auth): adiciona rota logout e botao logout no header

- Adiciona POST /auth/logout na API
- Adiciona botao Sair no LandingHeader quando autenticado
- Redirect para /apos logout

* test(auth): adiciona teste para logout no controller spec

- Adiciona teste para rota POST /logout retorna message de sucesso

* feat(dashboard): cria pagina dashboard com logout

- Cria DashboardPage.vue com cards informativos
- Adiciona botao Sair que chama API logout
- Cria dashboard.routes.ts
- Atualiza router com dashboardRoutes

* fix(auth): ajusta mensagens de validação para pt-BR e adiciona validation filter

* fix: remove reservas module e validation filter que nao existem

* fix(auth): retorna 200 OK no login conforme esperado pelo teste

---------



* Feature/4/us03 cadastrar credenciais de moradores (#26)

* feat(api): implementa cadastro de moradores (US03)

- POST /api/v1/residents (protegido por JWT + role ADMIN)
- DTO CreateResidentDto com class-validator
- Validador customizado CreateResidentValidator
- Gera senha temporária automática (8 caracteres) se não fornecida
- Cria User (RESIDENT) + Resident em transação
- Retorna accessToken para primeiro login do morador
- canBook padrão: true

* feat(api): adiciona JWT Guards para proteção de rotas (US03)

- JwtAuthGuard: valida JWT e injeta user no request
- RolesGuard: valida role do usuário (ADMIN)
- ResidentsController: aplica @UseGuards(JwtAuthGuard, RolesGuard)
- Registro dos guards no AuthModule

* fix(api): corrige tipos nos Guards JWT

- Adiciona interface AuthUser extendida no Request do Express
- Corrige tipagem para compatibility com TypeScript
- Mantém mensagens em português brasileiro

* fix(api): corrige E2E tests - adiciona DATABASE_URL no jest-e2e.json

- Configuração correta do DATABASE_URL para testes E2E
- Permite executar npm run test:e2e com sucesso

* feat(api): implementa CRUD de moradores (US03)

- GET /residents: lista moradores do condomínio
- GET /residents/:id: busca detalhes de morador
- POST /residents: cadastra novo morador com temporaryPassword
- PATCH /residents/:id/permissions: altera permissão canBook

- Adiciona schema migration para unitId opcional
- Adiciona DTOs CreateResidentDto e UpdatePermissionsDto
- Adiciona testes unitários TDD para os 3 novos métodos
- Documenta endpoints em Swagger com exemplos cURL
- Validações em português brasileiro

* refactor(api): move residents to separate module

- Create src/residents/ module with own controller, service, DTOs
- ResidentsController, ResidentsService, ResidentsModule
- Move CreateResidentDto, UpdatePermissionsDto, validator
- Remove residents from auth module
- All endpoints working (/residents, /residents/:id, /residents/:id/permissions)
- Tests and lint passing

* refactor(api): move resident methods to separate module

- Remove createResident, listResidents, getResidentById, updateResidentPermissions from AuthService
- Move to new ResidentsModule (/src/residents/)
- Create ResidentsService with all resident CRUD logic
- Create ResidentsService spec with tests (13 tests)
- Fix auth.service.spec.ts (remove resident tests)
- Fix dynamic import issue with bcrypt
- Update auth.module.ts
- Tests passing (71), lint passing

* fix(api): clean up resident tests

- Remove CreateResidentValidator from auth tests (moved to residents module)
- Add eslint disable comments for mock transaction

* feat(api): implement residents module (US03)

- Extract residents to separate module (/src/residents)
- Add ResidentsController, ResidentsService, DTOs, validators
- Endpoints: GET/POST /residents, GET /residents/:id, PATCH /residents/:id/permissions
- Move createResident logic from AuthService
- Add unit tests for ResidentsService (13 new tests)
- Clean up auth tests
- All tests passing (71), lint passing

* feat(web): implement dashboard components, residents pages, toast system and form validation

- Create reusable dashboard components (SideNavBar, TopAppBar, StatsCard, etc.)
- Implement residents CRUD pages (/residents, /residents/new, /residents/:id, /residents/:id/edit)
- Add global toast notification system with success/error/warning/info
- Add form validation composable with field-level errors
- Update login/register forms with client-side validation
- Fix password regex to accept any special character
- Add responsive layout with mobile hamburger menu
- Add unit tests for residents service

---------




* Feature/5/us031 login do morador (#27)

* feat: Middleware, Interceptors, Filters e Proteção de Rotas

- Implementa LoggerMiddleware com log em arquivo (logs/app.log)
- Adiciona TransformInterceptor para padronizar respostas (ResidentsController)
- Adiciona HttpExceptionFilter global para tratamento de erros
- Implementa proteção de rotas no frontend (router guards)
- Adiciona interceptor HTTP para tratar erro 401 (token expirado)
- Corrige salvamento do token no localStorage (sem JSON.stringify)

* feat: Role-based dashboards and reusable UI components

- Add AdminDashboard and ResidentDashboard with role-specific layouts
- Create reusable SideNavBar, TopAppBar, WelcomeSection components
- Add useUserRole composable and menuConfig for menu per role
- Add admin and resident route modules with proper paths
- Redirect /dashboard based on user role (ADMIN -> /admin, RESIDENT -> /resident)
- Add condominium name banner on ResidentDashboard
- Handle 404 routes by redirecting to dashboard

* fix: swagger US

---------



* Feature/6/us04 gerenciar áreas comuns (#28)

* feat: US04 e US05 - Áreas Comuns + Arquitetura de Exceções + Swagger aprimorado

## ✨ Novas Funcionalidades

### US04 - Áreas Comuns (Admin)
- CRUD completo: criar, listar, buscar, atualizar, deletar áreas
- Validação de horários (formato HH:MM)
- Validação de capacidade máxima
- Verificação de conflitos de nome por condomínio
- Proteção contra deleção de áreas com reservas ativas

### US05 - Visualizar Áreas Comuns (Admin + Morador)
- GET /common-areas - listar áreas (ambos roles)
- GET /common-areas/:id - buscar detalhes (ambos roles)

## 🏗️ Arquitetura

### Exceções de Domínio Customizadas
- DomainException (classe base com código de erro)
- ResidentNotFoundException (404)
- ResidentAccessDeniedException (403)
- EmailAlreadyExistsException (409)
- ResidentValidationException (400)
- CommonAreaNotFoundException (404)
- CommonAreaAccessDeniedException (403)
- TenantAccessDeniedException (403)
- CommonAreaValidationException (400)
- CommonAreaNameConflictException (409)
- CommonAreaHasReservationsException (409)

### Filtros de Exceção
- DomainExceptionFilter (filtro específico para DomainException)
- HttpExceptionFilter atualizado com factory para validação
- ValidationException factory para normalizar erros

## 🔐 Segurança

### Autenticação HttpOnly Cookies
- Cookie HttpOnly com JWT para segurança XSS
- SameSite=Strict para proteção CSRF
- JwtAuthGuard atualizado: Bearer primeiro, cookie como fallback
- Compatível com Swagger, Postman, cURL e frontend

## 📚 Swagger Aprimorado

### Documentação com User Stories
- Cada rota documentada com US (US01-US05)
- Tags organizadas: auth, residents, common-areas
- Descrições de acesso: Admin only vs Admin+Morador
- Regras de negócio documentadas (RN01, RN02, etc)
- Exportação automática de swagger.json

## 🧪 Testes
- 99 testes unitários passando (27 novos para CommonAreasService)
- Cobertura de exceções customizadas
- Testes de validação de DTOs

## 📝 Documentação
- Entrega atividade 16: Swagger com todas as evidências
- Descrições de testes para PDF

* chore: remove skills angular, add skills vue

* feat: rotas /condominium, placeholders por US, correção lista moradores e toast

* feat: sidebar collapsível com nome do condomínio, testes frontend e correções TS

- SideNavBar colapsável (w-16 ícones / w-72 completo) com botão toggle
- Nome do condomínio na sidebar (remove prefixo 'Condomínio')
- useSidebar composable compartilhado com sidebarCollapsed
- Transição suave na margem do main content
- TopAppBar hamburger apenas mobile
- Testes: useValidation, useToast, useApiError, useUserRole, SideNavBar, ResidentsListPage, ResidentsFormPage
- Testes backend: jwt-auth.guard, roles.guard, controllers, validators, interceptors, filters
- Removidos componentes antigos dashboard/ (layout, sidebar, topbar, rotas)
- Seed admin/resident com bcrypt
- Corrigidos erros TS (baseUrl, delete operator, jest mock)
- addToast clear() para isolamento de testes

---------




* feat: US04/US05 - CRUD areas comuns, visualizacao, manutencao, paginacao e testes (#29)



* feat(us06): consultar disponibilidade de áreas comuns (#30)

- Backend: endpoint GET /common-areas/:id/availability para verificar horários
- Backend: endpoint GET /common-areas/:id/busy-days para dias ocupados no mês
- Frontend: AvailabilityPage com calendário colorido e timeline de horários
- Admin: rota /condominium/availability adicionada ao menu
- Testes: 14 testes no service + 1 no controller (TDD)
- Fix: TypeScript error no CommonAreasListPage.spec.ts



* feat: implementa US06-US10 (reservas) com backend TDD e frontend completo (#31)

US06 - Consultar disponibilidade
- GET /common-areas/:id/availability com validação de dias/horários operacionais e conflitos
- GET /common-areas/:id/busy-days para calendário mensal colorido
- AvailabilityPage com calendário e timeline visual
- Inclusão na rota admin (/condominium/availability)
- Horários passados filtrados como indisponíveis

US07 - Realizar reserva
- POST /reservations com validação completa (área, tenant, manutenção, dias/horários operacionais, start < end, duração mínima 2h, morador existe e canBook, conflitos)
- Status PENDING se requiresApproval, APPROVED caso contrário
- NewReservationPage com calendário + timeline + seletores de horário com validação visual
- Confirmação via modal
- Query params para navegação entre páginas

US08 - Cancelar reserva
- PATCH /reservations/:id/cancel com trilha de auditoria (canceledById, canceledAt)
- Botão cancelar com confirmação em MyReservationsPage e ReservationsPage (admin)

US09 - Listar minhas reservas
- GET /reservations com paginação, filtro por status, escopo por papel
- Filtros: Próximas, Anteriores, Pendentes, Confirmadas, Canceladas
- Expand/collapse com detalhes e timeline do dia

US10 - Listar todas as reservas (admin)
- GET /reservations para ADMIN retorna todas do condomínio
- ReservationsPage com tabela, filtros, expand/collapse, cancelamento

Correções:
- Duplicata de @Post() no controller (POST caía no findAll)
- Sidebar CTA navegando para /resident/reservations/new
- Dashboard contando reservas do backend
- Suporte a múltiplos status (comma-separated) no filtro

Testes: 217 passando (de 213)



* feat: adiciona módulo de anúncios (#32)



* Deploy vercel (#33)

* feat: ocultar botão cancelar e mover reservas passadas para 'Anteriores'

- Backend: aceita ISO datetime no filtro 'from' para comparação precisa
- MyReservationsPage: 'Próximas' filtra por endTime atual; cancel some se passou
- ReservationsPage (admin): cancel some se reserva já passou

* chore: ajustes landing page, auth e criação de morador

- Landing: footer simplificado, CTA open source, Hero e Features ajustados
- Login/Register: removido card 'Não tem acesso? Falar com Adm'
- ResidentsForm: exibe senha temporária no toast ao criar morador
- TopAppBar: link Ajuda no dropdown do perfil
- SideNavBar: link Ajuda redireciona conforme role
- Backend: search param em common-areas e announcements

* feat: página 404, proteção XSS em rotas e correção de testes

- NotFoundPage: componente público para rotas inválidas
- Router: catch-all route + XSS guard redirecionando para 404
- SideNavBar.spec: corrigido contagem de menus e teste de link Ajuda

* feat: configure Vercel deployment (serverless handler, vercel.json, env vars, CORS)

---------



---------




* fix: remove postinstall from package.json

Remove postinstall script that breaks Vercel builds

* fix: remove postinstall, move dotenv to deps, add root build script for Vercel (#47)



* chore: trigger Vercel deploy with updated project settings (#48)

* fix: remove postinstall, move dotenv to deps, add root build script for Vercel

* chore: trigger Vercel deployment with updated project settings

---------



* chore: trigger Vercel deploy with fixed build command (#50)



* fix: configurar Vercel para build correto do monorepo (#53)

* fix: ajustar outputDirectory do web no vercel.json para apps/web/dist

* fix: build command condicional para funcionar em preview e production

* fix: rootDirectory apps/api + workflow deploy da raiz com --project

---------



* fix: corrigir outputDirectory no vercel.json do web (apps/web/dist -> dist) (#54)



---------




* Main para Develop (#67)

* Develop to Main (#34)

* Init: develop

* Test: SDD

* Fix: PRD and SSD Markdown

* Update checklist.md

* Merge pull request #16 from lucasgfaj/@lucasgfaj-create-dirs-and-tools

[Setup] Integração estrutural de Apps (Nest, Vue) e Docs

* Feature/15 import neon db and prisma orm (#17)

* Add Prisma and Neon

* chore: configure Prisma and update tech stack in documentation

- Install missing dependencies via npm i (package-lock.json) for Prisma local validation

- Update docs/ssd.md injecting exact package versions (NestJS v11, Prisma v7.6, Neon Postgres v16, Vue v3.5)

- Sync tech stack declarations inside docs/prd.md to match SSD versions

* feat: implement database schema and migrations for issue #15

---------



* feat: add docker-compose for local development and .env.example (#18)



* Feature/setup workspaces (#19)

* chore: configura monorepo com npm workspaces na raiz

* fix

---------



* ci: adiciona gatilho de push e badge de status no readme (#20)

* ci: adiciona gatilho de push e badge de status no readme

* fix: package

---------



* Feature/ci push and badge (#21)

* ci: adiciona gatilho de push e badges de status no readme

* docs: status do sistema

---------



* feat: Landing Page Modularization and Auth Layout (#23)

* web: inicio de diretorios

* feat: landing page implementation and web auth layout

* chore: package-lock.json fix

* fix: erro tailwind

---------



* Feature/us01 self service onboarding (#24)

* feat(api): implement US01 self-service onboarding and prisma 7 setup

- implement unified registration for Condominium and Admin User (US01)
- configure Prisma 7 with @prisma/adapter-pg for stable PostgreSQL connection
- setup global API prefix /api/v1 and validation pipes
- fix environment variables loading for monorepo environment
- add ACID transactions for tenant onboarding

* docs(api): setup Swagger UI and API welcome portal

- install and configure @nestjs/swagger
- document register endpoint with detailed examples and cURL commands
- enhance AppController with API metadata and health info
- polish Swagger UI description with PRD/SSD alignment

* feat(web): add self-service onboarding with login and register pages

* test(api): add unit tests for auth module following TDD

- Add AuthService unit tests (registerTenant, email conflict, JWT token)
- Add AuthController unit tests (register endpoint)
- Add E2E test skeleton for auth integration
- Fix AppController test to match actual implementation

* test(api): add unit and E2E tests with real database

- Add unit tests for AppController, AppService, PrismaService following TDD
- Improve password validation (min 8 chars, letter, number, special char)
- Add E2E tests with real database and cleanup after tests
- Create prisma.config.ts (required for Prisma 7)
- Update docker-compose.yml to use reserva_ai_db
- Add dev:api:test:e2e script to root package.json
- Update CI to run both unit and E2E tests with isolated test database

* refactor(auth): apply clean code with interfaces and separated validator

- Add explicit interfaces (RegisterTenantInput, RegisterTenantOutput, AuthPayload)
- Extract validation to RegisterTenantValidator class
- Update service to use validator and interfaces
- Update tests to match new contract (accessToken instead of access_token)
- Add validator unit tests (14 cases)
- Add dev:prisma script to root package.json

* feat(auth+web): connect frontend to backend with auth service

Backend:
- Add CORS configuration in main.ts
- Update auth controller to use explicit interfaces

Frontend:
- Create auth service with DTOs (RegisterTenantDTO, LoginDTO)
- Centralize auth logic (login, logout, token storage)
- Add Vitest for web unit tests
- Fix RegisterPage to use authService
- Fix LoginPage handler bug
- Update http interceptor for auth_token key

Scripts:
- Add dev:prisma:studio to package.json
- Add dev:web:test and dev:web:test:watch

* fix: ci/cd

---------




* feature/3/us02 gerenciar dados do condomínio (#25)

* feat(auth): implementa login US02 com TDD e validação

- Adiciona endpoint POST /auth/login
- Cria LoginValidator com validação de email/senha (SOLID)
- Adiciona LoginDto e interfaces LoginInput/LoginOutput
- Implementa método login() no AuthService com validação
- Adiciona testes unitários para login (4 testes)
- Adiciona testes E2E para login (5 cenários)
- Segue padrões DDD com validador separado

* fix: erros

* fix(auth): traduz msgs de erro para pt-BR e adiciona message nos endpoints

- Traduz ConflictException 'User already exists' para 'Usuário com este email já existe'
- Adiciona campo 'message' nas responses de register e login
- Atualiza exemplos no swagger com senha contendo caractere especial
- Traduz mensagens de validação do login validator para pt-BR

* fix: corrige lint errors e atualiza testes com message field

- Adiciona .catch no bootstrap() do main.ts
- Atualiza mocks com campo 'message' em auth.controller.spec.ts
- Remove variáveis não utilizadas em auth.service.spec.ts
- Atualiza e2e testes com message field
- Adiciona isexe como dependência

* fix: corrige todos lint errors com tipagem adequada

- Remove interfaces não utilizadas em auth.service.spec.ts
- Tipa mocks com tipos concretos em vez de any
- Adiciona ignore unbound-method nos testes de controller
- Tipa parâmetros res em e2e tests

* fix: corrige todos lint warnings com disable para supertest

- Tipa res em app.e2e-spec.ts
- Adiciona eslint-disable para supertest no-auth e app e2e

* fix(auth): implementa login real no frontend

- Corrige auth.api.ts para tipos corretos da API
- Implementa handleLogin chamando API real
- Salva token e dados no localStorage

* fix(auth): redireciona para dashboard se logado e exibe messages

- Adiciona router guard para redirect /login /register / para dashboard
- Exibe message de sucesso via alert apos login/register
- Exibe message de erro via alert
- Atualiza interfaces com message field

* feat(auth): adiciona rota logout e botao logout no header

- Adiciona POST /auth/logout na API
- Adiciona botao Sair no LandingHeader quando autenticado
- Redirect para /apos logout

* test(auth): adiciona teste para logout no controller spec

- Adiciona teste para rota POST /logout retorna message de sucesso

* feat(dashboard): cria pagina dashboard com logout

- Cria DashboardPage.vue com cards informativos
- Adiciona botao Sair que chama API logout
- Cria dashboard.routes.ts
- Atualiza router com dashboardRoutes

* fix(auth): ajusta mensagens de validação para pt-BR e adiciona validation filter

* fix: remove reservas module e validation filter que nao existem

* fix(auth): retorna 200 OK no login conforme esperado pelo teste

---------



* Feature/4/us03 cadastrar credenciais de moradores (#26)

* feat(api): implementa cadastro de moradores (US03)

- POST /api/v1/residents (protegido por JWT + role ADMIN)
- DTO CreateResidentDto com class-validator
- Validador customizado CreateResidentValidator
- Gera senha temporária automática (8 caracteres) se não fornecida
- Cria User (RESIDENT) + Resident em transação
- Retorna accessToken para primeiro login do morador
- canBook padrão: true

* feat(api): adiciona JWT Guards para proteção de rotas (US03)

- JwtAuthGuard: valida JWT e injeta user no request
- RolesGuard: valida role do usuário (ADMIN)
- ResidentsController: aplica @UseGuards(JwtAuthGuard, RolesGuard)
- Registro dos guards no AuthModule

* fix(api): corrige tipos nos Guards JWT

- Adiciona interface AuthUser extendida no Request do Express
- Corrige tipagem para compatibility com TypeScript
- Mantém mensagens em português brasileiro

* fix(api): corrige E2E tests - adiciona DATABASE_URL no jest-e2e.json

- Configuração correta do DATABASE_URL para testes E2E
- Permite executar npm run test:e2e com sucesso

* feat(api): implementa CRUD de moradores (US03)

- GET /residents: lista moradores do condomínio
- GET /residents/:id: busca detalhes de morador
- POST /residents: cadastra novo morador com temporaryPassword
- PATCH /residents/:id/permissions: altera permissão canBook

- Adiciona schema migration para unitId opcional
- Adiciona DTOs CreateResidentDto e UpdatePermissionsDto
- Adiciona testes unitários TDD para os 3 novos métodos
- Documenta endpoints em Swagger com exemplos cURL
- Validações em português brasileiro

* refactor(api): move residents to separate module

- Create src/residents/ module with own controller, service, DTOs
- ResidentsController, ResidentsService, ResidentsModule
- Move CreateResidentDto, UpdatePermissionsDto, validator
- Remove residents from auth module
- All endpoints working (/residents, /residents/:id, /residents/:id/permissions)
- Tests and lint passing

* refactor(api): move resident methods to separate module

- Remove createResident, listResidents, getResidentById, updateResidentPermissions from AuthService
- Move to new ResidentsModule (/src/residents/)
- Create ResidentsService with all resident CRUD logic
- Create ResidentsService spec with tests (13 tests)
- Fix auth.service.spec.ts (remove resident tests)
- Fix dynamic import issue with bcrypt
- Update auth.module.ts
- Tests passing (71), lint passing

* fix(api): clean up resident tests

- Remove CreateResidentValidator from auth tests (moved to residents module)
- Add eslint disable comments for mock transaction

* feat(api): implement residents module (US03)

- Extract residents to separate module (/src/residents)
- Add ResidentsController, ResidentsService, DTOs, validators
- Endpoints: GET/POST /residents, GET /residents/:id, PATCH /residents/:id/permissions
- Move createResident logic from AuthService
- Add unit tests for ResidentsService (13 new tests)
- Clean up auth tests
- All tests passing (71), lint passing

* feat(web): implement dashboard components, residents pages, toast system and form validation

- Create reusable dashboard components (SideNavBar, TopAppBar, StatsCard, etc.)
- Implement residents CRUD pages (/residents, /residents/new, /residents/:id, /residents/:id/edit)
- Add global toast notification system with success/error/warning/info
- Add form validation composable with field-level errors
- Update login/register forms with client-side validation
- Fix password regex to accept any special character
- Add responsive layout with mobile hamburger menu
- Add unit tests for residents service

---------




* Feature/5/us031 login do morador (#27)

* feat: Middleware, Interceptors, Filters e Proteção de Rotas

- Implementa LoggerMiddleware com log em arquivo (logs/app.log)
- Adiciona TransformInterceptor para padronizar respostas (ResidentsController)
- Adiciona HttpExceptionFilter global para tratamento de erros
- Implementa proteção de rotas no frontend (router guards)
- Adiciona interceptor HTTP para tratar erro 401 (token expirado)
- Corrige salvamento do token no localStorage (sem JSON.stringify)

* feat: Role-based dashboards and reusable UI components

- Add AdminDashboard and ResidentDashboard with role-specific layouts
- Create reusable SideNavBar, TopAppBar, WelcomeSection components
- Add useUserRole composable and menuConfig for menu per role
- Add admin and resident route modules with proper paths
- Redirect /dashboard based on user role (ADMIN -> /admin, RESIDENT -> /resident)
- Add condominium name banner on ResidentDashboard
- Handle 404 routes by redirecting to dashboard

* fix: swagger US

---------



* Feature/6/us04 gerenciar áreas comuns (#28)

* feat: US04 e US05 - Áreas Comuns + Arquitetura de Exceções + Swagger aprimorado

## ✨ Novas Funcionalidades

### US04 - Áreas Comuns (Admin)
- CRUD completo: criar, listar, buscar, atualizar, deletar áreas
- Validação de horários (formato HH:MM)
- Validação de capacidade máxima
- Verificação de conflitos de nome por condomínio
- Proteção contra deleção de áreas com reservas ativas

### US05 - Visualizar Áreas Comuns (Admin + Morador)
- GET /common-areas - listar áreas (ambos roles)
- GET /common-areas/:id - buscar detalhes (ambos roles)

## 🏗️ Arquitetura

### Exceções de Domínio Customizadas
- DomainException (classe base com código de erro)
- ResidentNotFoundException (404)
- ResidentAccessDeniedException (403)
- EmailAlreadyExistsException (409)
- ResidentValidationException (400)
- CommonAreaNotFoundException (404)
- CommonAreaAccessDeniedException (403)
- TenantAccessDeniedException (403)
- CommonAreaValidationException (400)
- CommonAreaNameConflictException (409)
- CommonAreaHasReservationsException (409)

### Filtros de Exceção
- DomainExceptionFilter (filtro específico para DomainException)
- HttpExceptionFilter atualizado com factory para validação
- ValidationException factory para normalizar erros

## 🔐 Segurança

### Autenticação HttpOnly Cookies
- Cookie HttpOnly com JWT para segurança XSS
- SameSite=Strict para proteção CSRF
- JwtAuthGuard atualizado: Bearer primeiro, cookie como fallback
- Compatível com Swagger, Postman, cURL e frontend

## 📚 Swagger Aprimorado

### Documentação com User Stories
- Cada rota documentada com US (US01-US05)
- Tags organizadas: auth, residents, common-areas
- Descrições de acesso: Admin only vs Admin+Morador
- Regras de negócio documentadas (RN01, RN02, etc)
- Exportação automática de swagger.json

## 🧪 Testes
- 99 testes unitários passando (27 novos para CommonAreasService)
- Cobertura de exceções customizadas
- Testes de validação de DTOs

## 📝 Documentação
- Entrega atividade 16: Swagger com todas as evidências
- Descrições de testes para PDF

* chore: remove skills angular, add skills vue

* feat: rotas /condominium, placeholders por US, correção lista moradores e toast

* feat: sidebar collapsível com nome do condomínio, testes frontend e correções TS

- SideNavBar colapsável (w-16 ícones / w-72 completo) com botão toggle
- Nome do condomínio na sidebar (remove prefixo 'Condomínio')
- useSidebar composable compartilhado com sidebarCollapsed
- Transição suave na margem do main content
- TopAppBar hamburger apenas mobile
- Testes: useValidation, useToast, useApiError, useUserRole, SideNavBar, ResidentsListPage, ResidentsFormPage
- Testes backend: jwt-auth.guard, roles.guard, controllers, validators, interceptors, filters
- Removidos componentes antigos dashboard/ (layout, sidebar, topbar, rotas)
- Seed admin/resident com bcrypt
- Corrigidos erros TS (baseUrl, delete operator, jest mock)
- addToast clear() para isolamento de testes

---------




* feat: US04/US05 - CRUD areas comuns, visualizacao, manutencao, paginacao e testes (#29)



* feat(us06): consultar disponibilidade de áreas comuns (#30)

- Backend: endpoint GET /common-areas/:id/availability para verificar horários
- Backend: endpoint GET /common-areas/:id/busy-days para dias ocupados no mês
- Frontend: AvailabilityPage com calendário colorido e timeline de horários
- Admin: rota /condominium/availability adicionada ao menu
- Testes: 14 testes no service + 1 no controller (TDD)
- Fix: TypeScript error no CommonAreasListPage.spec.ts



* feat: implementa US06-US10 (reservas) com backend TDD e frontend completo (#31)

US06 - Consultar disponibilidade
- GET /common-areas/:id/availability com validação de dias/horários operacionais e conflitos
- GET /common-areas/:id/busy-days para calendário mensal colorido
- AvailabilityPage com calendário e timeline visual
- Inclusão na rota admin (/condominium/availability)
- Horários passados filtrados como indisponíveis

US07 - Realizar reserva
- POST /reservations com validação completa (área, tenant, manutenção, dias/horários operacionais, start < end, duração mínima 2h, morador existe e canBook, conflitos)
- Status PENDING se requiresApproval, APPROVED caso contrário
- NewReservationPage com calendário + timeline + seletores de horário com validação visual
- Confirmação via modal
- Query params para navegação entre páginas

US08 - Cancelar reserva
- PATCH /reservations/:id/cancel com trilha de auditoria (canceledById, canceledAt)
- Botão cancelar com confirmação em MyReservationsPage e ReservationsPage (admin)

US09 - Listar minhas reservas
- GET /reservations com paginação, filtro por status, escopo por papel
- Filtros: Próximas, Anteriores, Pendentes, Confirmadas, Canceladas
- Expand/collapse com detalhes e timeline do dia

US10 - Listar todas as reservas (admin)
- GET /reservations para ADMIN retorna todas do condomínio
- ReservationsPage com tabela, filtros, expand/collapse, cancelamento

Correções:
- Duplicata de @Post() no controller (POST caía no findAll)
- Sidebar CTA navegando para /resident/reservations/new
- Dashboard contando reservas do backend
- Suporte a múltiplos status (comma-separated) no filtro

Testes: 217 passando (de 213)



* feat: adiciona módulo de anúncios (#32)



* Deploy vercel (#33)

* feat: ocultar botão cancelar e mover reservas passadas para 'Anteriores'

- Backend: aceita ISO datetime no filtro 'from' para comparação precisa
- MyReservationsPage: 'Próximas' filtra por endTime atual; cancel some se passou
- ReservationsPage (admin): cancel some se reserva já passou

* chore: ajustes landing page, auth e criação de morador

- Landing: footer simplificado, CTA open source, Hero e Features ajustados
- Login/Register: removido card 'Não tem acesso? Falar com Adm'
- ResidentsForm: exibe senha temporária no toast ao criar morador
- TopAppBar: link Ajuda no dropdown do perfil
- SideNavBar: link Ajuda redireciona conforme role
- Backend: search param em common-areas e announcements

* feat: página 404, proteção XSS em rotas e correção de testes

- NotFoundPage: componente público para rotas inválidas
- Router: catch-all route + XSS guard redirecionando para 404
- SideNavBar.spec: corrigido contagem de menus e teste de link Ajuda

* feat: configure Vercel deployment (serverless handler, vercel.json, env vars, CORS)

---------



---------




* fix: remove postinstall from package.json

Remove postinstall script that breaks Vercel builds

* fix: remove postinstall, move dotenv to deps, add root build script for Vercel (#47)



* chore: trigger Vercel deploy with updated project settings (#48)

* fix: remove postinstall, move dotenv to deps, add root build script for Vercel

* chore: trigger Vercel deployment with updated project settings

---------



* chore: trigger Vercel deploy with fixed build command (#50)



* fix: ajustar outputDirectory do web no vercel.json para apps/web/dist

* fix: build command condicional para funcionar em preview e production

* fix: rootDirectory apps/api + workflow deploy da raiz com --project

* fix: configurar Vercel para build correto do monorepo (#53)

* fix: ajustar outputDirectory do web no vercel.json para apps/web/dist

* fix: build command condicional para funcionar em preview e production

* fix: rootDirectory apps/api + workflow deploy da raiz com --project

---------



* fix: corrigir outputDirectory no vercel.json do web (apps/web/dist -> dist) (#54)



* fix: ajustar deploy Vercel da API e web, corrigir logger para serverless (#56)

* fix: corrigir leitura do token JWT do localStorage (JSON.parse) (#57)

* feat: adicionar timeout e retry mechanism nas requisições auth

* feat: adicionar timeout e retry config na API (Prisma, NestJS, Vercel) (#59)



* fix: alinhar workflow de deploy web com o da develop (sem --project)

* fix: outputDirectory dist em vez de apps/web/dist (deploy roda de apps/web)

* fix: usar vercel deploy --prebuilt em vez de build remoto

* fix: --prebuilt no web, API volta ao original

* fix: usar vercel build + vercel deploy --prebuilt

* chore: add deploy badge to README

* fix: redirect para /condominium/dashboard apos registro

---------





* Feature/agents md (#68)

* Develop to Main (#34)

* Init: develop

* Test: SDD

* Fix: PRD and SSD Markdown

* Update checklist.md

* Merge pull request #16 from lucasgfaj/@lucasgfaj-create-dirs-and-tools

[Setup] Integração estrutural de Apps (Nest, Vue) e Docs

* Feature/15 import neon db and prisma orm (#17)

* Add Prisma and Neon

* chore: configure Prisma and update tech stack in documentation

- Install missing dependencies via npm i (package-lock.json) for Prisma local validation

- Update docs/ssd.md injecting exact package versions (NestJS v11, Prisma v7.6, Neon Postgres v16, Vue v3.5)

- Sync tech stack declarations inside docs/prd.md to match SSD versions

* feat: implement database schema and migrations for issue #15

---------



* feat: add docker-compose for local development and .env.example (#18)



* Feature/setup workspaces (#19)

* chore: configura monorepo com npm workspaces na raiz

* fix

---------



* ci: adiciona gatilho de push e badge de status no readme (#20)

* ci: adiciona gatilho de push e badge de status no readme

* fix: package

---------



* Feature/ci push and badge (#21)

* ci: adiciona gatilho de push e badges de status no readme

* docs: status do sistema

---------



* feat: Landing Page Modularization and Auth Layout (#23)

* web: inicio de diretorios

* feat: landing page implementation and web auth layout

* chore: package-lock.json fix

* fix: erro tailwind

---------



* Feature/us01 self service onboarding (#24)

* feat(api): implement US01 self-service onboarding and prisma 7 setup

- implement unified registration for Condominium and Admin User (US01)
- configure Prisma 7 with @prisma/adapter-pg for stable PostgreSQL connection
- setup global API prefix /api/v1 and validation pipes
- fix environment variables loading for monorepo environment
- add ACID transactions for tenant onboarding

* docs(api): setup Swagger UI and API welcome portal

- install and configure @nestjs/swagger
- document register endpoint with detailed examples and cURL commands
- enhance AppController with API metadata and health info
- polish Swagger UI description with PRD/SSD alignment

* feat(web): add self-service onboarding with login and register pages

* test(api): add unit tests for auth module following TDD

- Add AuthService unit tests (registerTenant, email conflict, JWT token)
- Add AuthController unit tests (register endpoint)
- Add E2E test skeleton for auth integration
- Fix AppController test to match actual implementation

* test(api): add unit and E2E tests with real database

- Add unit tests for AppController, AppService, PrismaService following TDD
- Improve password validation (min 8 chars, letter, number, special char)
- Add E2E tests with real database and cleanup after tests
- Create prisma.config.ts (required for Prisma 7)
- Update docker-compose.yml to use reserva_ai_db
- Add dev:api:test:e2e script to root package.json
- Update CI to run both unit and E2E tests with isolated test database

* refactor(auth): apply clean code with interfaces and separated validator

- Add explicit interfaces (RegisterTenantInput, RegisterTenantOutput, AuthPayload)
- Extract validation to RegisterTenantValidator class
- Update service to use validator and interfaces
- Update tests to match new contract (accessToken instead of access_token)
- Add validator unit tests (14 cases)
- Add dev:prisma script to root package.json

* feat(auth+web): connect frontend to backend with auth service

Backend:
- Add CORS configuration in main.ts
- Update auth controller to use explicit interfaces

Frontend:
- Create auth service with DTOs (RegisterTenantDTO, LoginDTO)
- Centralize auth logic (login, logout, token storage)
- Add Vitest for web unit tests
- Fix RegisterPage to use authService
- Fix LoginPage handler bug
- Update http interceptor for auth_token key

Scripts:
- Add dev:prisma:studio to package.json
- Add dev:web:test and dev:web:test:watch

* fix: ci/cd

---------




* feature/3/us02 gerenciar dados do condomínio (#25)

* feat(auth): implementa login US02 com TDD e validação

- Adiciona endpoint POST /auth/login
- Cria LoginValidator com validação de email/senha (SOLID)
- Adiciona LoginDto e interfaces LoginInput/LoginOutput
- Implementa método login() no AuthService com validação
- Adiciona testes unitários para login (4 testes)
- Adiciona testes E2E para login (5 cenários)
- Segue padrões DDD com validador separado

* fix: erros

* fix(auth): traduz msgs de erro para pt-BR e adiciona message nos endpoints

- Traduz ConflictException 'User already exists' para 'Usuário com este email já existe'
- Adiciona campo 'message' nas responses de register e login
- Atualiza exemplos no swagger com senha contendo caractere especial
- Traduz mensagens de validação do login validator para pt-BR

* fix: corrige lint errors e atualiza testes com message field

- Adiciona .catch no bootstrap() do main.ts
- Atualiza mocks com campo 'message' em auth.controller.spec.ts
- Remove variáveis não utilizadas em auth.service.spec.ts
- Atualiza e2e testes com message field
- Adiciona isexe como dependência

* fix: corrige todos lint errors com tipagem adequada

- Remove interfaces não utilizadas em auth.service.spec.ts
- Tipa mocks com tipos concretos em vez de any
- Adiciona ignore unbound-method nos testes de controller
- Tipa parâmetros res em e2e tests

* fix: corrige todos lint warnings com disable para supertest

- Tipa res em app.e2e-spec.ts
- Adiciona eslint-disable para supertest no-auth e app e2e

* fix(auth): implementa login real no frontend

- Corrige auth.api.ts para tipos corretos da API
- Implementa handleLogin chamando API real
- Salva token e dados no localStorage

* fix(auth): redireciona para dashboard se logado e exibe messages

- Adiciona router guard para redirect /login /register / para dashboard
- Exibe message de sucesso via alert apos login/register
- Exibe message de erro via alert
- Atualiza interfaces com message field

* feat(auth): adiciona rota logout e botao logout no header

- Adiciona POST /auth/logout na API
- Adiciona botao Sair no LandingHeader quando autenticado
- Redirect para /apos logout

* test(auth): adiciona teste para logout no controller spec

- Adiciona teste para rota POST /logout retorna message de sucesso

* feat(dashboard): cria pagina dashboard com logout

- Cria DashboardPage.vue com cards informativos
- Adiciona botao Sair que chama API logout
- Cria dashboard.routes.ts
- Atualiza router com dashboardRoutes

* fix(auth): ajusta mensagens de validação para pt-BR e adiciona validation filter

* fix: remove reservas module e validation filter que nao existem

* fix(auth): retorna 200 OK no login conforme esperado pelo teste

---------



* Feature/4/us03 cadastrar credenciais de moradores (#26)

* feat(api): implementa cadastro de moradores (US03)

- POST /api/v1/residents (protegido por JWT + role ADMIN)
- DTO CreateResidentDto com class-validator
- Validador customizado CreateResidentValidator
- Gera senha temporária automática (8 caracteres) se não fornecida
- Cria User (RESIDENT) + Resident em transação
- Retorna accessToken para primeiro login do morador
- canBook padrão: true

* feat(api): adiciona JWT Guards para proteção de rotas (US03)

- JwtAuthGuard: valida JWT e injeta user no request
- RolesGuard: valida role do usuário (ADMIN)
- ResidentsController: aplica @UseGuards(JwtAuthGuard, RolesGuard)
- Registro dos guards no AuthModule

* fix(api): corrige tipos nos Guards JWT

- Adiciona interface AuthUser extendida no Request do Express
- Corrige tipagem para compatibility com TypeScript
- Mantém mensagens em português brasileiro

* fix(api): corrige E2E tests - adiciona DATABASE_URL no jest-e2e.json

- Configuração correta do DATABASE_URL para testes E2E
- Permite executar npm run test:e2e com sucesso

* feat(api): implementa CRUD de moradores (US03)

- GET /residents: lista moradores do condomínio
- GET /residents/:id: busca detalhes de morador
- POST /residents: cadastra novo morador com temporaryPassword
- PATCH /residents/:id/permissions: altera permissão canBook

- Adiciona schema migration para unitId opcional
- Adiciona DTOs CreateResidentDto e UpdatePermissionsDto
- Adiciona testes unitários TDD para os 3 novos métodos
- Documenta endpoints em Swagger com exemplos cURL
- Validações em português brasileiro

* refactor(api): move residents to separate module

- Create src/residents/ module with own controller, service, DTOs
- ResidentsController, ResidentsService, ResidentsModule
- Move CreateResidentDto, UpdatePermissionsDto, validator
- Remove residents from auth module
- All endpoints working (/residents, /residents/:id, /residents/:id/permissions)
- Tests and lint passing

* refactor(api): move resident methods to separate module

- Remove createResident, listResidents, getResidentById, updateResidentPermissions from AuthService
- Move to new ResidentsModule (/src/residents/)
- Create ResidentsService with all resident CRUD logic
- Create ResidentsService spec with tests (13 tests)
- Fix auth.service.spec.ts (remove resident tests)
- Fix dynamic import issue with bcrypt
- Update auth.module.ts
- Tests passing (71), lint passing

* fix(api): clean up resident tests

- Remove CreateResidentValidator from auth tests (moved to residents module)
- Add eslint disable comments for mock transaction

* feat(api): implement residents module (US03)

- Extract residents to separate module (/src/residents)
- Add ResidentsController, ResidentsService, DTOs, validators
- Endpoints: GET/POST /residents, GET /residents/:id, PATCH /residents/:id/permissions
- Move createResident logic from AuthService
- Add unit tests for ResidentsService (13 new tests)
- Clean up auth tests
- All tests passing (71), lint passing

* feat(web): implement dashboard components, residents pages, toast system and form validation

- Create reusable dashboard components (SideNavBar, TopAppBar, StatsCard, etc.)
- Implement residents CRUD pages (/residents, /residents/new, /residents/:id, /residents/:id/edit)
- Add global toast notification system with success/error/warning/info
- Add form validation composable with field-level errors
- Update login/register forms with client-side validation
- Fix password regex to accept any special character
- Add responsive layout with mobile hamburger menu
- Add unit tests for residents service

---------




* Feature/5/us031 login do morador (#27)

* feat: Middleware, Interceptors, Filters e Proteção de Rotas

- Implementa LoggerMiddleware com log em arquivo (logs/app.log)
- Adiciona TransformInterceptor para padronizar respostas (ResidentsController)
- Adiciona HttpExceptionFilter global para tratamento de erros
- Implementa proteção de rotas no frontend (router guards)
- Adiciona interceptor HTTP para tratar erro 401 (token expirado)
- Corrige salvamento do token no localStorage (sem JSON.stringify)

* feat: Role-based dashboards and reusable UI components

- Add AdminDashboard and ResidentDashboard with role-specific layouts
- Create reusable SideNavBar, TopAppBar, WelcomeSection components
- Add useUserRole composable and menuConfig for menu per role
- Add admin and resident route modules with proper paths
- Redirect /dashboard based on user role (ADMIN -> /admin, RESIDENT -> /resident)
- Add condominium name banner on ResidentDashboard
- Handle 404 routes by redirecting to dashboard

* fix: swagger US

---------



* Feature/6/us04 gerenciar áreas comuns (#28)

* feat: US04 e US05 - Áreas Comuns + Arquitetura de Exceções + Swagger aprimorado

## ✨ Novas Funcionalidades

### US04 - Áreas Comuns (Admin)
- CRUD completo: criar, listar, buscar, atualizar, deletar áreas
- Validação de horários (formato HH:MM)
- Validação de capacidade máxima
- Verificação de conflitos de nome por condomínio
- Proteção contra deleção de áreas com reservas ativas

### US05 - Visualizar Áreas Comuns (Admin + Morador)
- GET /common-areas - listar áreas (ambos roles)
- GET /common-areas/:id - buscar detalhes (ambos roles)

## 🏗️ Arquitetura

### Exceções de Domínio Customizadas
- DomainException (classe base com código de erro)
- ResidentNotFoundException (404)
- ResidentAccessDeniedException (403)
- EmailAlreadyExistsException (409)
- ResidentValidationException (400)
- CommonAreaNotFoundException (404)
- CommonAreaAccessDeniedException (403)
- TenantAccessDeniedException (403)
- CommonAreaValidationException (400)
- CommonAreaNameConflictException (409)
- CommonAreaHasReservationsException (409)

### Filtros de Exceção
- DomainExceptionFilter (filtro específico para DomainException)
- HttpExceptionFilter atualizado com factory para validação
- ValidationException factory para normalizar erros

## 🔐 Segurança

### Autenticação HttpOnly Cookies
- Cookie HttpOnly com JWT para segurança XSS
- SameSite=Strict para proteção CSRF
- JwtAuthGuard atualizado: Bearer primeiro, cookie como fallback
- Compatível com Swagger, Postman, cURL e frontend

## 📚 Swagger Aprimorado

### Documentação com User Stories
- Cada rota documentada com US (US01-US05)
- Tags organizadas: auth, residents, common-areas
- Descrições de acesso: Admin only vs Admin+Morador
- Regras de negócio documentadas (RN01, RN02, etc)
- Exportação automática de swagger.json

## 🧪 Testes
- 99 testes unitários passando (27 novos para CommonAreasService)
- Cobertura de exceções customizadas
- Testes de validação de DTOs

## 📝 Documentação
- Entrega atividade 16: Swagger com todas as evidências
- Descrições de testes para PDF

* chore: remove skills angular, add skills vue

* feat: rotas /condominium, placeholders por US, correção lista moradores e toast

* feat: sidebar collapsível com nome do condomínio, testes frontend e correções TS

- SideNavBar colapsável (w-16 ícones / w-72 completo) com botão toggle
- Nome do condomínio na sidebar (remove prefixo 'Condomínio')
- useSidebar composable compartilhado com sidebarCollapsed
- Transição suave na margem do main content
- TopAppBar hamburger apenas mobile
- Testes: useValidation, useToast, useApiError, useUserRole, SideNavBar, ResidentsListPage, ResidentsFormPage
- Testes backend: jwt-auth.guard, roles.guard, controllers, validators, interceptors, filters
- Removidos componentes antigos dashboard/ (layout, sidebar, topbar, rotas)
- Seed admin/resident com bcrypt
- Corrigidos erros TS (baseUrl, delete operator, jest mock)
- addToast clear() para isolamento de testes

---------




* feat: US04/US05 - CRUD areas comuns, visualizacao, manutencao, paginacao e testes (#29)



* feat(us06): consultar disponibilidade de áreas comuns (#30)

- Backend: endpoint GET /common-areas/:id/availability para verificar horários
- Backend: endpoint GET /common-areas/:id/busy-days para dias ocupados no mês
- Frontend: AvailabilityPage com calendário colorido e timeline de horários
- Admin: rota /condominium/availability adicionada ao menu
- Testes: 14 testes no service + 1 no controller (TDD)
- Fix: TypeScript error no CommonAreasListPage.spec.ts



* feat: implementa US06-US10 (reservas) com backend TDD e frontend completo (#31)

US06 - Consultar disponibilidade
- GET /common-areas/:id/availability com validação de dias/horários operacionais e conflitos
- GET /common-areas/:id/busy-days para calendário mensal colorido
- AvailabilityPage com calendário e timeline visual
- Inclusão na rota admin (/condominium/availability)
- Horários passados filtrados como indisponíveis

US07 - Realizar reserva
- POST /reservations com validação completa (área, tenant, manutenção, dias/horários operacionais, start < end, duração mínima 2h, morador existe e canBook, conflitos)
- Status PENDING se requiresApproval, APPROVED caso contrário
- NewReservationPage com calendário + timeline + seletores de horário com validação visual
- Confirmação via modal
- Query params para navegação entre páginas

US08 - Cancelar reserva
- PATCH /reservations/:id/cancel com trilha de auditoria (canceledById, canceledAt)
- Botão cancelar com confirmação em MyReservationsPage e ReservationsPage (admin)

US09 - Listar minhas reservas
- GET /reservations com paginação, filtro por status, escopo por papel
- Filtros: Próximas, Anteriores, Pendentes, Confirmadas, Canceladas
- Expand/collapse com detalhes e timeline do dia

US10 - Listar todas as reservas (admin)
- GET /reservations para ADMIN retorna todas do condomínio
- ReservationsPage com tabela, filtros, expand/collapse, cancelamento

Correções:
- Duplicata de @Post() no controller (POST caía no findAll)
- Sidebar CTA navegando para /resident/reservations/new
- Dashboard contando reservas do backend
- Suporte a múltiplos status (comma-separated) no filtro

Testes: 217 passando (de 213)



* feat: adiciona módulo de anúncios (#32)



* Deploy vercel (#33)

* feat: ocultar botão cancelar e mover reservas passadas para 'Anteriores'

- Backend: aceita ISO datetime no filtro 'from' para comparação precisa
- MyReservationsPage: 'Próximas' filtra por endTime atual; cancel some se passou
- ReservationsPage (admin): cancel some se reserva já passou

* chore: ajustes landing page, auth e criação de morador

- Landing: footer simplificado, CTA open source, Hero e Features ajustados
- Login/Register: removido card 'Não tem acesso? Falar com Adm'
- ResidentsForm: exibe senha temporária no toast ao criar morador
- TopAppBar: link Ajuda no dropdown do perfil
- SideNavBar: link Ajuda redireciona conforme role
- Backend: search param em common-areas e announcements

* feat: página 404, proteção XSS em rotas e correção de testes

- NotFoundPage: componente público para rotas inválidas
- Router: catch-all route + XSS guard redirecionando para 404
- SideNavBar.spec: corrigido contagem de menus e teste de link Ajuda

* feat: configure Vercel deployment (serverless handler, vercel.json, env vars, CORS)

---------



---------




* fix: remove postinstall from package.json

Remove postinstall script that breaks Vercel builds

* fix: remove postinstall, move dotenv to deps, add root build script for Vercel (#47)



* chore: trigger Vercel deploy with updated project settings (#48)

* fix: remove postinstall, move dotenv to deps, add root build script for Vercel

* chore: trigger Vercel deployment with updated project settings

---------



* chore: trigger Vercel deploy with fixed build command (#50)



* fix: ajustar outputDirectory do web no vercel.json para apps/web/dist

* fix: build command condicional para funcionar em preview e production

* fix: rootDirectory apps/api + workflow deploy da raiz com --project

* fix: configurar Vercel para build correto do monorepo (#53)

* fix: ajustar outputDirectory do web no vercel.json para apps/web/dist

* fix: build command condicional para funcionar em preview e production

* fix: rootDirectory apps/api + workflow deploy da raiz com --project

---------



* fix: corrigir outputDirectory no vercel.json do web (apps/web/dist -> dist) (#54)



* fix: ajustar deploy Vercel da API e web, corrigir logger para serverless (#56)

* fix: corrigir leitura do token JWT do localStorage (JSON.parse) (#57)

* feat: …