### PR TITLE
feat: add loading skeleton to all list, form, detail and dashboard pages

### DIFF
--- a/apps/web/src/modules/admin/pages/AdminDashboard.vue
+++ b/apps/web/src/modules/admin/pages/AdminDashboard.vue
@@ -19,8 +19,59 @@
       <div class="flex-1 p-4 md:p-6 lg:p-8 space-y-6 md:space-y-8 lg:space-y-12 w-full max-w-full">
         <WelcomeSection title="Dashboard Principal" :description="welcomeMessage" />
 
+        <!-- Loading skeleton -->
+        <div v-if="loadingReservations" class="space-y-6 md:space-y-8">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+            <div v-for="n in 4" :key="n" class="bg-white rounded-2xl p-5 md:p-6 border border-slate-100 shadow-sm animate-pulse">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-10 h-10 bg-slate-200 rounded-xl" />
+                <div class="space-y-2 flex-1">
+                  <div class="h-3 bg-slate-200 rounded w-1/2" />
+                  <div class="h-6 bg-slate-200 rounded w-1/3" />
+                </div>
+              </div>
+              <div class="h-1.5 bg-slate-200 rounded-full" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 md:gap-8">
+            <div class="col-span-1 lg:col-span-7 space-y-4">
+              <div class="h-6 bg-slate-200 rounded w-1/3 mb-2 animate-pulse" />
+              <div v-for="n in 3" :key="n" class="bg-white rounded-xl p-4 border border-slate-100 animate-pulse">
+                <div class="flex items-center gap-3">
+                  <div class="w-10 h-10 bg-slate-200 rounded-lg" />
+                  <div class="flex-1 space-y-2">
+                    <div class="h-4 bg-slate-200 rounded w-1/4" />
+                    <div class="h-3 bg-slate-200 rounded w-1/2" />
+                  </div>
+                  <div class="h-5 bg-slate-200 rounded w-16" />
+                </div>
+              </div>
+            </div>
+            <div class="col-span-1 lg:col-span-5 space-y-6">
+              <div class="bg-white rounded-xl p-5 border border-slate-100 animate-pulse">
+                <div class="space-y-3">
+                  <div v-for="n in 3" :key="n" class="h-10 bg-slate-200 rounded-lg" />
+                </div>
+              </div>
+              <div class="bg-white rounded-xl p-5 border border-slate-100 animate-pulse">
+                <div class="h-5 bg-slate-200 rounded w-1/3 mb-4" />
+                <div class="space-y-3">
+                  <div v-for="n in 3" :key="n" class="flex items-center gap-3">
+                    <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                    <div class="flex-1 space-y-1">
+                      <div class="h-3 bg-slate-200 rounded w-1/3" />
+                      <div class="h-3 bg-slate-200 rounded w-1/2" />
+                    </div>
+                    <div class="h-3 bg-slate-200 rounded w-10" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Stats Cards -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+        <div v-if="!loadingReservations" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
           <StatsCard title="Reservas Pendentes" :value="pendingCount" icon="pending_actions" :trend="pendingTrend" variant="primary" />
           <StatsCard title="Total de Moradores" :value="residentCount" icon="group" :subtitle="residentSubtitle" variant="primary" />
           <StatsCard title="Áreas Comuns" :value="areaCount" icon="pool" :subtitle="areaSubtitle" variant="primary" />
@@ -28,17 +79,14 @@
         </div>
 
         <!-- Main Grid -->
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 md:gap-8">
+        <div v-if="!loadingReservations" class="grid grid-cols-1 lg:grid-cols-12 gap-6 md:gap-8">
           <div class="col-span-1 lg:col-span-7 space-y-4 md:space-y-6">
             <div class="flex items-center justify-between mb-2">
               <h3 class="text-lg md:text-xl font-bold text-cyan-900 tracking-tight">Próximas Reservas</h3>
               <router-link to="/condominium/reservations" class="text-sm font-semibold text-primary hover:underline">Ver calendário completo</router-link>
             </div>
 
-            <div v-if="loadingReservations" class="flex items-center justify-center py-8">
-              <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
-            </div>
-            <div v-else-if="upcomingReservations.length === 0" class="text-center py-8 text-slate-400 text-sm">
+            <div v-if="upcomingReservations.length === 0" class="text-center py-8 text-slate-400 text-sm">
               Nenhuma reserva futura agendada.
             </div>
             <div v-else class="space-y-3 md:space-y-4">

--- a/apps/web/src/modules/admin/pages/AnnouncementsPage.vue
+++ b/apps/web/src/modules/admin/pages/AnnouncementsPage.vue
@@ -36,15 +36,31 @@
           </button>
         </div>
 
-        <div v-if="loading" class="flex items-center justify-center py-12">
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="hidden md:block space-y-4 max-w-3xl">
+          <div v-for="n in 3" :key="n" class="bg-white rounded-2xl p-5 md:p-6 border border-slate-100 shadow-sm animate-pulse">
+            <div class="flex items-start gap-4">
+              <div class="w-9 h-9 bg-slate-200 rounded-full shrink-0" />
+              <div class="flex-1 space-y-3">
+                <div class="h-5 bg-slate-200 rounded w-1/3" />
+                <div class="h-4 bg-slate-200 rounded w-full" />
+                <div class="h-4 bg-slate-200 rounded w-2/3" />
+                <div class="h-3 bg-slate-200 rounded w-1/4" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Mobile loading -->
+        <div v-if="loading" class="md:hidden flex items-center justify-center py-12">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
         </div>
 
-        <div v-else-if="errorMessage" class="text-sm text-red-600 bg-red-50 rounded-xl px-4 py-3 border border-red-200 max-w-2xl">
+        <div v-if="!loading && errorMessage" class="text-sm text-red-600 bg-red-50 rounded-xl px-4 py-3 border border-red-200 max-w-2xl">
           {{ errorMessage }}
         </div>
 
-        <template v-else>
+        <template v-if="!loading && !errorMessage">
           <div v-if="showForm" class="max-w-2xl mb-8">
             <div class="bg-white rounded-2xl p-6 md:p-8 border border-slate-100 shadow-sm">
               <h2 class="text-lg font-bold text-cyan-900 mb-4">Novo Comunicado</h2>

--- a/apps/web/src/modules/admin/pages/CommonAreasFormPage.vue
+++ b/apps/web/src/modules/admin/pages/CommonAreasFormPage.vue
@@ -26,9 +26,27 @@
           <span class="text-slate-900 font-medium whitespace-nowrap">{{ isEditMode ? 'Editar' : 'Nova' }}</span>
         </nav>
 
-        <!-- Loading (edit mode) -->
-        <div v-if="loading && isEditMode" class="flex items-center justify-center py-20">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        <!-- Loading skeleton (edit mode) -->
+        <div v-if="loading && isEditMode" class="w-full max-w-4xl mx-auto">
+          <div class="bg-surface-container-lowest rounded-2xl p-6 md:p-8 border border-slate-100 animate-pulse">
+            <div class="h-6 bg-slate-200 rounded w-1/3 mb-8" />
+            <div class="space-y-6">
+              <div><div class="h-4 bg-slate-200 rounded w-1/6 mb-2" /><div class="h-10 bg-slate-200 rounded-xl" /></div>
+              <div><div class="h-4 bg-slate-200 rounded w-1/6 mb-2" /><div class="h-20 bg-slate-200 rounded-xl" /></div>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div><div class="h-4 bg-slate-200 rounded w-1/6 mb-2" /><div class="h-10 bg-slate-200 rounded-xl" /></div>
+                <div><div class="h-4 bg-slate-200 rounded w-1/6 mb-2" /><div class="h-10 bg-slate-200 rounded-xl" /></div>
+              </div>
+              <div><div class="h-4 bg-slate-200 rounded w-1/6 mb-2" /><div class="h-10 bg-slate-200 rounded-xl" /></div>
+              <div className="flex flex-wrap gap-2"><div v-for="n in 7" :key="n" class="h-9 bg-slate-200 rounded-lg w-14" /></div>
+              <div className="h-14 bg-slate-200 rounded-xl" />
+              <div className="h-14 bg-slate-200 rounded-xl" />
+              <div className="flex gap-3 pt-4">
+                <div class="flex-1 h-11 bg-slate-200 rounded-xl" />
+                <div class="flex-1 h-11 bg-slate-200 rounded-xl" />
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Form -->

--- a/apps/web/src/modules/admin/pages/CommonAreasPage.vue
+++ b/apps/web/src/modules/admin/pages/CommonAreasPage.vue
@@ -42,12 +42,12 @@
               type="text"
             />
           </div>
-          <select v-model="filterApproval" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 bg-surface-container-low border-none rounded-xl text-sm md:text-base">
+          <select v-model="filterApproval" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 pr-8 md:pr-10 bg-surface-container-low border-none rounded-xl text-sm md:text-base appearance-none">
             <option value="all">Todas</option>
             <option value="required">Requer aprovação</option>
             <option value="free">Livre</option>
           </select>
-          <select v-model="filterMaintenance" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 bg-surface-container-low border-none rounded-xl text-sm md:text-base">
+          <select v-model="filterMaintenance" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 pr-8 md:pr-10 bg-surface-container-low border-none rounded-xl text-sm md:text-base appearance-none">
             <option value="all">Qualquer status</option>
             <option value="maintenance">Em manutenção</option>
             <option value="available">Disponível</option>

--- a/apps/web/src/modules/admin/pages/CondominiumSettingsPage.vue
+++ b/apps/web/src/modules/admin/pages/CondominiumSettingsPage.vue
@@ -31,11 +31,29 @@
             </div>
           </div>
 
-          <div v-if="loading" class="flex items-center justify-center py-16">
-            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          <!-- Loading skeleton -->
+          <div v-if="loading" class="p-6 md:p-8 max-w-xl animate-pulse">
+            <div class="space-y-5">
+              <div>
+                <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+                <div class="h-10 bg-slate-200 rounded-xl" />
+              </div>
+              <div>
+                <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+                <div class="h-10 bg-slate-200 rounded-xl" />
+              </div>
+              <div>
+                <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+                <div class="h-10 bg-slate-200 rounded-xl" />
+              </div>
+              <div class="flex items-center gap-3 pt-4 border-t border-slate-100">
+                <div class="h-11 bg-slate-200 rounded-xl w-36" />
+                <div class="h-11 bg-slate-200 rounded-xl w-24" />
+              </div>
+            </div>
           </div>
 
-          <template v-else>
+          <template v-if="!loading">
             <div class="p-6 md:p-8 max-w-xl">
               <div class="space-y-5">
                 <div>

--- a/apps/web/src/modules/admin/pages/ReportsPage.vue
+++ b/apps/web/src/modules/admin/pages/ReportsPage.vue
@@ -27,11 +27,46 @@
           <p class="text-slate-500 ml-[52px]">Visão geral de reservas e ocupação do condomínio</p>
         </div>
 
-        <div v-if="loading" class="flex items-center justify-center py-16">
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="hidden md:block space-y-6">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+            <div v-for="n in 4" :key="n" class="bg-white rounded-2xl p-5 md:p-6 border border-slate-100 shadow-sm animate-pulse">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-10 h-10 bg-slate-200 rounded-xl" />
+                <div class="space-y-2 flex-1">
+                  <div class="h-3 bg-slate-200 rounded w-1/2" />
+                  <div class="h-6 bg-slate-200 rounded w-1/3" />
+                </div>
+              </div>
+              <div class="h-1.5 bg-slate-200 rounded-full" />
+            </div>
+          </div>
+
+          <div class="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden">
+            <div class="px-6 md:px-8 pt-6 pb-4 border-b border-slate-100">
+              <div class="h-5 bg-slate-200 rounded w-1/4 mb-2 animate-pulse" />
+              <div class="h-4 bg-slate-200 rounded w-1/3 animate-pulse" />
+            </div>
+            <div class="p-8">
+              <div class="space-y-4">
+                <div v-for="n in 4" :key="n" class="flex items-center gap-4 animate-pulse">
+                  <div class="h-4 bg-slate-200 rounded w-1/4" />
+                  <div class="h-4 bg-slate-200 rounded w-16" />
+                  <div class="h-4 bg-slate-200 rounded w-16" />
+                  <div class="h-4 bg-slate-200 rounded w-16" />
+                  <div class="h-4 bg-slate-200 rounded w-16" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Mobile loading -->
+        <div v-if="loading" class="md:hidden flex items-center justify-center py-16">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
         </div>
 
-        <template v-else>
+        <template v-if="!loading">
           <!-- Summary cards -->
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 mb-8">
             <div class="bg-white rounded-2xl p-5 md:p-6 border border-slate-100 shadow-sm">

--- a/apps/web/src/modules/admin/pages/ReservationsPage.vue
+++ b/apps/web/src/modules/admin/pages/ReservationsPage.vue
@@ -27,11 +27,27 @@
           <p class="text-slate-500 ml-[52px]">Todas as reservas do condomínio</p>
         </div>
 
-        <div v-if="loading" class="flex items-center justify-center py-12">
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="hidden md:block bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden p-8">
+          <div class="space-y-4">
+            <div v-for="n in 4" :key="n" class="flex items-center gap-4 animate-pulse">
+              <div class="w-9 h-9 bg-slate-200 rounded-lg" />
+              <div class="h-4 bg-slate-200 rounded w-1/5" />
+              <div class="h-4 bg-slate-200 rounded w-1/6" />
+              <div class="h-4 bg-slate-200 rounded w-1/6" />
+              <div class="h-4 bg-slate-200 rounded w-1/6" />
+              <div class="h-6 bg-slate-200 rounded w-20" />
+              <div class="h-4 bg-slate-200 rounded w-8" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Mobile loading spinner -->
+        <div v-if="loading" class="md:hidden flex items-center justify-center py-12">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
         </div>
 
-        <template v-else>
+        <template v-if="!loading">
           <!-- Filters -->
           <div class="flex flex-wrap items-center gap-3 mb-6">
             <button

--- a/apps/web/src/modules/blocks/pages/BlocksFormPage.vue
+++ b/apps/web/src/modules/blocks/pages/BlocksFormPage.vue
@@ -11,7 +11,19 @@
           <p class="text-on-surface-variant mt-1 md:mt-2 text-sm md:text-base">{{ isEdit ? 'Atualize as informações do bloco' : 'Cadastre um novo bloco no condomínio' }}</p>
         </div>
 
-        <form @submit.prevent="handleSubmit" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm">
+        <!-- Loading skeleton for edit mode -->
+        <div v-if="isEdit && loading" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm animate-pulse">
+          <div>
+            <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+            <div class="h-11 bg-slate-200 rounded-xl" />
+          </div>
+          <div class="flex items-center gap-3 pt-2">
+            <div class="h-11 bg-slate-200 rounded-xl w-28" />
+            <div class="h-11 bg-slate-200 rounded-xl w-24" />
+          </div>
+        </div>
+
+        <form v-else @submit.prevent="handleSubmit" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm">
           <div>
             <label class="block text-sm font-medium text-slate-700 mb-1.5">Nome do Bloco</label>
             <input v-model="form.name" type="text" class="w-full px-4 py-3 bg-surface-container-low border-none rounded-xl text-sm" placeholder="Ex: Bloco A" required />
@@ -55,16 +67,20 @@ const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
 
 const isEdit = computed(() => !!route.params.id)
 const saving = ref(false)
+const loading = ref(false)
 const form = ref({ name: '' })
 const errors = ref<Record<string, string>>({})
 
 onMounted(async () => {
   if (isEdit.value) {
+    loading.value = true
     try {
       const block = await blocksService.getById(route.params.id as string)
       form.value.name = block.name
     } catch (err) {
       handleError(err, 'Erro ao carregar bloco')
+    } finally {
+      loading.value = false
     }
   }
 })

--- a/apps/web/src/modules/blocks/pages/BlocksListPage.vue
+++ b/apps/web/src/modules/blocks/pages/BlocksListPage.vue
@@ -18,7 +18,28 @@
         </div>
 
         <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl overflow-hidden shadow-sm">
-          <div class="overflow-x-auto">
+          <!-- Loading skeleton -->
+          <div v-if="loading" class="hidden md:block p-8">
+            <div class="space-y-4">
+              <div v-for="n in 4" :key="n" class="flex items-center gap-4 animate-pulse">
+                <div class="flex-1 space-y-2">
+                  <div class="h-4 bg-slate-200 rounded w-1/3" />
+                </div>
+                <div class="flex gap-2">
+                  <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                  <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Mobile spinner -->
+          <div v-if="loading" class="md:hidden p-8 text-center text-slate-400">
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
+            <p class="mt-2">Carregando...</p>
+          </div>
+
+          <div v-if="!loading" class="overflow-x-auto">
             <table class="w-full">
               <thead class="bg-surface-container-low">
                 <tr>

--- a/apps/web/src/modules/resident/pages/AnnouncementsPage.vue
+++ b/apps/web/src/modules/resident/pages/AnnouncementsPage.vue
@@ -27,20 +27,36 @@
           <p class="text-slate-500 ml-[52px]">Avisos e comunicados do condomínio</p>
         </div>
 
-        <div v-if="loading" class="flex items-center justify-center py-12">
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="hidden md:block space-y-4 max-w-3xl">
+          <div v-for="n in 3" :key="n" class="bg-white rounded-2xl p-5 md:p-6 border border-slate-100 shadow-sm animate-pulse">
+            <div class="flex items-start gap-4">
+              <div class="w-9 h-9 bg-slate-200 rounded-full shrink-0" />
+              <div class="flex-1 space-y-3">
+                <div class="h-5 bg-slate-200 rounded w-1/3" />
+                <div class="h-4 bg-slate-200 rounded w-full" />
+                <div class="h-4 bg-slate-200 rounded w-2/3" />
+                <div class="h-3 bg-slate-200 rounded w-1/4" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Mobile loading -->
+        <div v-if="loading" class="md:hidden flex items-center justify-center py-12">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
         </div>
 
-        <div v-else-if="errorMessage" class="text-sm text-red-600 bg-red-50 rounded-xl px-4 py-3 border border-red-200 max-w-2xl">
+        <div v-if="!loading && errorMessage" class="text-sm text-red-600 bg-red-50 rounded-xl px-4 py-3 border border-red-200 max-w-2xl">
           {{ errorMessage }}
         </div>
 
-        <div v-else-if="announcements.length === 0" class="text-center py-12 text-slate-400">
+        <div v-if="!loading && !errorMessage && announcements.length === 0" class="text-center py-12 text-slate-400">
           <span class="material-symbols-outlined text-4xl mb-2">campaign</span>
           <p>Nenhum comunicado publicado.</p>
         </div>
 
-        <div v-else class="space-y-4 max-w-3xl">
+        <div v-if="!loading && !errorMessage && announcements.length > 0" class="space-y-4 max-w-3xl">
           <div
             v-for="item in announcements"
             :key="item.id"

--- a/apps/web/src/modules/resident/pages/AvailabilityPage.vue
+++ b/apps/web/src/modules/resident/pages/AvailabilityPage.vue
@@ -28,8 +28,34 @@
           <p class="text-slate-500 ml-[52px]">Selecione uma área e um dia para ver os horários livres</p>
         </div>
 
-        <div v-if="loadingAreas" class="flex items-center justify-center py-12">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <!-- Loading skeleton -->
+        <div v-if="loadingAreas" class="space-y-6 animate-pulse">
+          <div class="bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+            <div class="flex items-center gap-4">
+              <div class="flex-1">
+                <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+                <div class="h-10 bg-slate-200 rounded-xl max-w-xs" />
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <div class="xl:col-span-2 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <div class="flex items-center justify-between mb-4">
+                <div class="h-8 w-8 bg-slate-200 rounded-lg" />
+                <div class="h-5 bg-slate-200 rounded w-40" />
+                <div class="h-8 w-8 bg-slate-200 rounded-lg" />
+              </div>
+              <div class="grid grid-cols-7 gap-1">
+                <div v-for="n in 35" :key="n" class="h-11 bg-slate-200 rounded-lg" />
+              </div>
+            </div>
+            <div class="bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <div class="flex flex-col items-center justify-center h-full py-8">
+                <div class="w-12 h-12 bg-slate-200 rounded-full mb-3" />
+                <div class="h-4 bg-slate-200 rounded w-1/2" />
+              </div>
+            </div>
+          </div>
         </div>
 
         <template v-else>
@@ -41,7 +67,7 @@
                 <select
                   v-model="selectedAreaId"
                   @change="onAreaChange"
-                  class="w-full max-w-xs px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                  class="w-full max-w-xs px-3 py-2.5 pr-8 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all appearance-none"
                 >
                   <option value="" disabled>Selecione uma área</option>
                   <option v-for="area in areas" :key="area.id" :value="area.id">

--- a/apps/web/src/modules/resident/pages/CommonAreaDetailPage.vue
+++ b/apps/web/src/modules/resident/pages/CommonAreaDetailPage.vue
@@ -26,9 +26,59 @@
           <span class="text-slate-900 font-medium whitespace-nowrap">{{ area?.name || 'Detalhes' }}</span>
         </nav>
 
-        <!-- Loading State -->
-        <div v-if="loading" class="flex items-center justify-center py-12 md:py-20">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="w-full max-w-4xl mx-auto space-y-4 md:space-y-6 lg:space-y-8 animate-pulse">
+          <div class="flex flex-col sm:flex-row items-start justify-between gap-4">
+            <div class="flex items-center gap-4 md:gap-6">
+              <div class="w-14 h-14 md:w-16 lg:w-20 rounded-2xl bg-slate-200" />
+              <div class="space-y-2">
+                <div class="h-6 bg-slate-200 rounded w-48" />
+                <div class="h-4 bg-slate-200 rounded w-72" />
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+            <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 lg:p-8 border border-slate-100">
+              <div class="h-5 bg-slate-200 rounded w-1/3 mb-6" />
+              <div class="space-y-4">
+                <div class="flex items-center gap-3">
+                  <div class="w-6 h-6 bg-slate-200 rounded" />
+                  <div class="space-y-1 flex-1">
+                    <div class="h-3 bg-slate-200 rounded w-1/4" />
+                    <div class="h-5 bg-slate-200 rounded w-1/3" />
+                  </div>
+                </div>
+                <div class="flex items-start gap-3">
+                  <div class="w-6 h-6 bg-slate-200 rounded mt-0.5" />
+                  <div class="space-y-1.5 flex-1">
+                    <div class="h-3 bg-slate-200 rounded w-1/3" />
+                    <div class="flex gap-1.5">
+                      <div v-for="n in 7" :key="n" class="w-8 h-8 bg-slate-200 rounded-full" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 lg:p-8 border border-slate-100">
+              <div class="h-5 bg-slate-200 rounded w-1/4 mb-6" />
+              <div class="space-y-4">
+                <div class="flex items-center gap-3">
+                  <div class="w-6 h-6 bg-slate-200 rounded" />
+                  <div class="space-y-1 flex-1">
+                    <div class="h-3 bg-slate-200 rounded w-1/4" />
+                    <div class="h-5 bg-slate-200 rounded w-2/3" />
+                  </div>
+                </div>
+                <div class="flex items-center gap-3">
+                  <div class="w-6 h-6 bg-slate-200 rounded" />
+                  <div class="space-y-1 flex-1">
+                    <div class="h-3 bg-slate-200 rounded w-1/4" />
+                    <div class="h-5 bg-slate-200 rounded w-1/2" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Content -->

--- a/apps/web/src/modules/resident/pages/MyReservationsPage.vue
+++ b/apps/web/src/modules/resident/pages/MyReservationsPage.vue
@@ -35,12 +35,27 @@
           <p class="text-slate-500 ml-[52px]">Gerencie suas reservas nas áreas comuns</p>
         </div>
 
-        <!-- Loading -->
-        <div v-if="loading" class="flex items-center justify-center py-12">
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="hidden md:block space-y-3">
+          <div v-for="n in 4" :key="n" class="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden animate-pulse">
+            <div class="flex items-center gap-4 p-4 md:p-5">
+              <div class="w-11 h-11 bg-slate-200 rounded-xl shrink-0" />
+              <div class="flex-1 space-y-2">
+                <div class="h-5 bg-slate-200 rounded w-1/3" />
+                <div class="h-4 bg-slate-200 rounded w-1/2" />
+              </div>
+              <div class="h-6 bg-slate-200 rounded w-20" />
+              <div class="w-6 h-6 bg-slate-200 rounded" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Mobile loading -->
+        <div v-if="loading" class="md:hidden flex items-center justify-center py-12">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
         </div>
 
-        <template v-else>
+        <template v-if="!loading">
           <!-- Filters -->
           <div class="flex items-center gap-2 mb-6 overflow-x-auto pb-2">
             <button

--- a/apps/web/src/modules/resident/pages/NewReservationPage.vue
+++ b/apps/web/src/modules/resident/pages/NewReservationPage.vue
@@ -29,9 +29,34 @@
           <p class="text-slate-500 ml-[52px]">Selecione área, dia e horário para reservar</p>
         </div>
 
-        <!-- Loading -->
-        <div v-if="loadingAreas" class="flex items-center justify-center py-12">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <!-- Loading skeleton -->
+        <div v-if="loadingAreas" class="space-y-6 animate-pulse">
+          <div class="bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+            <div class="flex items-center gap-4 flex-wrap">
+              <div class="flex-1 min-w-[200px]">
+                <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+                <div class="h-10 bg-slate-200 rounded-xl max-w-xs" />
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 xl:grid-cols-5 gap-6">
+            <div class="xl:col-span-3 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <div class="flex items-center justify-between mb-4">
+                <div class="h-8 w-8 bg-slate-200 rounded-lg" />
+                <div class="h-5 bg-slate-200 rounded w-40" />
+                <div class="h-8 w-8 bg-slate-200 rounded-lg" />
+              </div>
+              <div class="grid grid-cols-7 gap-1">
+                <div v-for="n in 35" :key="n" class="h-11 bg-slate-200 rounded-lg" />
+              </div>
+            </div>
+            <div class="xl:col-span-2 bg-white rounded-2xl p-4 md:p-6 border border-slate-100 shadow-sm">
+              <div class="flex flex-col items-center justify-center h-full py-8">
+                <div class="w-12 h-12 bg-slate-200 rounded-full mb-3" />
+                <div class="h-4 bg-slate-200 rounded w-1/2" />
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Success -->
@@ -56,7 +81,7 @@
                 <select
                   v-model="selectedAreaId"
                   @change="onAreaChange"
-                  class="w-full max-w-xs px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                  class="w-full max-w-xs px-3 py-2.5 pr-8 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all appearance-none"
                 >
                   <option value="" disabled>Selecione uma área</option>
                   <option v-for="a in areas" :key="a.id" :value="a.id">{{ a.name }}</option>
@@ -193,7 +218,7 @@
                     <select
                       v-model="selectedStart"
                       @change="onTimeChange"
-                      class="w-full px-2.5 py-2 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                      class="w-full px-2.5 py-2 pr-8 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all appearance-none"
                     >
                       <option value="" disabled>Selecione</option>
                       <option v-for="t in timeOptions" :key="t" :value="t" :disabled="t >= result.closeTime">{{ t }}</option>
@@ -204,7 +229,7 @@
                     <select
                       v-model="selectedEnd"
                       @change="onTimeChange"
-                      class="w-full px-2.5 py-2 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                      class="w-full px-2.5 py-2 pr-8 bg-slate-50 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all appearance-none"
                     >
                       <option value="" disabled>Selecione</option>
                       <option v-for="t in endTimeOptions" :key="t" :value="t">{{ t }}</option>

--- a/apps/web/src/modules/resident/pages/ResidentDashboard.vue
+++ b/apps/web/src/modules/resident/pages/ResidentDashboard.vue
@@ -23,18 +23,54 @@
             Olá, {{ userName }}!
           </h2>
           <p class="text-on-surface-variant mt-1">
-            {{ welcomeMessage }}
+            {{ loading ? 'Carregando...' : welcomeMessage }}
           </p>
         </div>
 
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="space-y-6 md:space-y-8">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+            <div v-for="n in 2" :key="n" class="bg-white rounded-2xl p-5 md:p-6 border border-slate-100 shadow-sm animate-pulse">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-10 h-10 bg-slate-200 rounded-xl" />
+                <div class="space-y-2 flex-1">
+                  <div class="h-3 bg-slate-200 rounded w-1/2" />
+                  <div class="h-6 bg-slate-200 rounded w-1/3" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 md:gap-8">
+            <div class="col-span-1 lg:col-span-7 space-y-4">
+              <div class="h-6 bg-slate-200 rounded w-1/3 animate-pulse" />
+              <div v-for="n in 2" :key="n" class="bg-white rounded-xl p-4 border border-slate-100 animate-pulse">
+                <div class="flex items-center gap-3">
+                  <div class="w-10 h-10 bg-slate-200 rounded-lg" />
+                  <div class="flex-1 space-y-2">
+                    <div class="h-4 bg-slate-200 rounded w-1/3" />
+                    <div class="h-3 bg-slate-200 rounded w-1/2" />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col-span-1 lg:col-span-5 space-y-6">
+              <div class="bg-white rounded-xl p-5 border border-slate-100 animate-pulse">
+                <div class="space-y-3">
+                  <div v-for="n in 2" :key="n" class="h-10 bg-slate-200 rounded-lg" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Stats -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+        <div v-if="!loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
           <StatsCard title="Minhas Reservas" :value="reservationsCount" icon="event_available" trend="Próximas" variant="primary" />
           <StatsCard title="Áreas Disponíveis" :value="commonAreasCount" icon="pool" variant="primary" />
         </div>
 
         <!-- Main Grid -->
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 md:gap-8">
+        <div v-if="!loading" class="grid grid-cols-1 lg:grid-cols-12 gap-6 md:gap-8">
           <!-- Left: My Reservations -->
           <div class="col-span-1 lg:col-span-7 space-y-4">
             <div class="flex items-center justify-between">
@@ -128,6 +164,7 @@ const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
 const user = authService.getUser()
 const userName = ref(user?.name || 'Morador')
 
+const loading = ref(true)
 const commonAreasCount = ref(0)
 const reservations = ref<Reservation[]>([])
 
@@ -171,6 +208,12 @@ async function fetchReservations() {
   }
 }
 
+onMounted(async () => {
+  loading.value = true
+  await Promise.all([fetchCommonAreas(), fetchReservations()])
+  loading.value = false
+})
+
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr)
   return d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'long' })
@@ -197,8 +240,5 @@ const handleQuickAction = (actionId: string) => {
   }
 }
 
-onMounted(() => {
-  fetchCommonAreas()
-  fetchReservations()
-})
+
 </script>

--- a/apps/web/src/modules/residents/pages/ResidentsDetailPage.vue
+++ b/apps/web/src/modules/residents/pages/ResidentsDetailPage.vue
@@ -29,9 +29,42 @@
           <span class="text-slate-900 font-medium whitespace-nowrap">Detalhes</span>
         </nav>
 
-        <!-- Loading State -->
-        <div v-if="loading" class="flex items-center justify-center py-12 md:py-20">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <!-- Loading skeleton -->
+        <div v-if="loading" class="w-full max-w-5xl mx-auto space-y-4 md:space-y-6 lg:space-y-8 animate-pulse">
+          <div class="flex flex-col sm:flex-row items-start justify-between gap-4">
+            <div class="flex items-center gap-4 md:gap-6">
+              <div class="w-14 h-14 md:w-16 lg:w-20 rounded-2xl bg-slate-200" />
+              <div class="space-y-2">
+                <div class="h-6 bg-slate-200 rounded w-48" />
+                <div class="h-4 bg-slate-200 rounded w-32" />
+              </div>
+            </div>
+            <div class="flex gap-2 w-full sm:w-auto">
+              <div class="flex-1 sm:flex-none h-11 bg-slate-200 rounded-xl w-24" />
+              <div class="flex-1 sm:flex-none h-11 bg-slate-200 rounded-xl w-24" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+            <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 lg:p-8 border border-slate-100">
+              <div class="h-5 bg-slate-200 rounded w-1/3 mb-6" />
+              <div class="space-y-5">
+                <div><div class="h-3 bg-slate-200 rounded w-1/4 mb-1" /><div class="h-5 bg-slate-200 rounded w-2/3" /></div>
+                <div><div class="h-3 bg-slate-200 rounded w-1/4 mb-1" /><div class="h-5 bg-slate-200 rounded w-3/4" /></div>
+                <div><div class="h-3 bg-slate-200 rounded w-1/4 mb-1" /><div class="h-5 bg-slate-200 rounded w-1/2" /></div>
+              </div>
+            </div>
+            <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 lg:p-8 border border-slate-100">
+              <div class="h-5 bg-slate-200 rounded w-1/4 mb-6" />
+              <div class="space-y-5">
+                <div><div class="h-3 bg-slate-200 rounded w-1/4 mb-1" /><div class="h-5 bg-slate-200 rounded w-2/3" /></div>
+                <div><div class="h-3 bg-slate-200 rounded w-1/4 mb-1" /><div class="h-5 bg-slate-200 rounded w-3/4" /></div>
+              </div>
+            </div>
+          </div>
+          <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 lg:p-8 border border-slate-100">
+            <div class="h-5 bg-slate-200 rounded w-1/3 mb-6" />
+            <div class="h-11 bg-slate-200 rounded-xl w-32" />
+          </div>
         </div>
 
         <!-- Content -->

--- a/apps/web/src/modules/residents/pages/ResidentsFormPage.vue
+++ b/apps/web/src/modules/residents/pages/ResidentsFormPage.vue
@@ -34,8 +34,35 @@
         </nav>
 
         <!-- Loading State -->
-        <div v-if="loading && isEditMode" class="flex items-center justify-center py-12 md:py-20">
-          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <div v-if="loading && isEditMode" class="w-full max-w-4xl mx-auto">
+          <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 lg:p-8 border border-slate-100 animate-pulse">
+            <div class="h-6 bg-slate-200 rounded w-1/3 mb-8" />
+            <div class="space-y-6">
+              <div>
+                <div class="h-4 bg-slate-200 rounded w-1/6 mb-2" />
+                <div class="h-10 bg-slate-200 rounded-xl" />
+              </div>
+              <div>
+                <div class="h-4 bg-slate-200 rounded w-1/6 mb-2" />
+                <div class="h-10 bg-slate-200 rounded-xl" />
+              </div>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                <div>
+                  <div class="h-4 bg-slate-200 rounded w-1/6 mb-2" />
+                  <div class="h-10 bg-slate-200 rounded-xl" />
+                </div>
+                <div>
+                  <div class="h-4 bg-slate-200 rounded w-1/6 mb-2" />
+                  <div class="h-10 bg-slate-200 rounded-xl" />
+                </div>
+              </div>
+              <div class="h-14 bg-slate-200 rounded-xl" />
+              <div class="flex gap-4">
+                <div class="flex-1 h-11 bg-slate-200 rounded-xl" />
+                <div class="flex-1 h-11 bg-slate-200 rounded-xl" />
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Form -->

--- a/apps/web/src/modules/residents/pages/ResidentsListPage.vue
+++ b/apps/web/src/modules/residents/pages/ResidentsListPage.vue
@@ -46,7 +46,7 @@
               type="text"
             />
           </div>
-          <select v-model="filterStatus" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 bg-surface-container-low border-none rounded-xl text-sm md:text-base">
+          <select v-model="filterStatus" class="w-full sm:w-auto px-3 md:px-4 py-2.5 md:py-3 pr-8 md:pr-10 bg-surface-container-low border-none rounded-xl text-sm md:text-base appearance-none">
             <option value="all">Todos</option>
             <option value="active">Ativos</option>
             <option value="inactive">Inativos</option>
@@ -55,8 +55,33 @@
 
         <!-- Residents Table - RESPONSIVE -->
         <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl overflow-hidden shadow-sm">
+          <!-- Loading skeleton -->
+          <div v-if="loading" class="hidden md:block p-8">
+            <div class="space-y-4">
+              <div v-for="n in 4" :key="n" class="flex items-center gap-4 animate-pulse">
+                <div class="w-10 h-10 bg-slate-200 rounded-full" />
+                <div class="flex-1 space-y-2">
+                  <div class="h-4 bg-slate-200 rounded w-1/4" />
+                  <div class="h-3 bg-slate-200 rounded w-1/3" />
+                </div>
+                <div class="h-4 bg-slate-200 rounded w-20" />
+                <div class="h-4 bg-slate-200 rounded w-16" />
+                <div class="flex gap-2">
+                  <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                  <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Mobile spinner -->
+          <div v-if="loading" class="md:hidden p-8 text-center text-slate-400">
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
+            <p class="mt-2">Carregando...</p>
+          </div>
+
           <!-- Desktop Table -->
-          <div class="hidden md:block overflow-x-auto">
+          <div v-if="!loading" class="hidden md:block overflow-x-auto">
             <table class="w-full">
               <thead class="bg-surface-container-low">
                 <tr>
@@ -119,7 +144,11 @@
 
           <!-- Mobile Cards -->
           <div class="md:hidden divide-y divide-slate-100">
-            <div v-if="filteredResidents.length === 0" class="p-8 text-center text-slate-400">
+            <div v-if="loading" class="p-8 text-center text-slate-400">
+              <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
+              <p class="mt-2">Carregando...</p>
+            </div>
+            <div v-else-if="filteredResidents.length === 0" class="p-8 text-center text-slate-400">
               <span class="material-symbols-outlined text-5xl">group_remove</span>
               <p class="mt-2">Nenhum morador encontrado</p>
             </div>

--- a/apps/web/src/modules/units/pages/UnitsFormPage.vue
+++ b/apps/web/src/modules/units/pages/UnitsFormPage.vue
@@ -11,7 +11,23 @@
           <p class="text-on-surface-variant mt-1 md:mt-2 text-sm md:text-base">{{ isEdit ? 'Atualize as informações da unidade' : 'Cadastre uma nova unidade no condomínio' }}</p>
         </div>
 
-        <form @submit.prevent="handleSubmit" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm">
+        <!-- Loading skeleton for edit mode -->
+        <div v-if="isEdit && loading" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm animate-pulse">
+          <div>
+            <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+            <div class="h-11 bg-slate-200 rounded-xl" />
+          </div>
+          <div>
+            <div class="h-4 bg-slate-200 rounded w-1/4 mb-1.5" />
+            <div class="h-11 bg-slate-200 rounded-xl" />
+          </div>
+          <div class="flex items-center gap-3 pt-2">
+            <div class="h-11 bg-slate-200 rounded-xl w-28" />
+            <div class="h-11 bg-slate-200 rounded-xl w-24" />
+          </div>
+        </div>
+
+        <form v-else @submit.prevent="handleSubmit" class="bg-surface-container-lowest rounded-2xl md:rounded-3xl p-4 md:p-6 space-y-6 shadow-sm">
           <div>
             <label class="block text-sm font-medium text-slate-700 mb-1.5">Número da Unidade</label>
             <input v-model="form.number" type="text" class="w-full px-4 py-3 bg-surface-container-low border-none rounded-xl text-sm" placeholder="Ex: 101" required />
@@ -20,7 +36,7 @@
 
           <div>
             <label class="block text-sm font-medium text-slate-700 mb-1.5">Bloco</label>
-            <select v-model="form.blockId" class="w-full px-4 py-3 bg-surface-container-low border-none rounded-xl text-sm" :required="!isEdit">
+            <select v-model="form.blockId" class="w-full px-4 py-3 pr-8 bg-surface-container-low border-none rounded-xl text-sm appearance-none" :required="!isEdit">
               <option value="" disabled>Selecione um bloco</option>
               <option v-for="block in blocks" :key="block.id" :value="block.id">{{ block.name }}</option>
             </select>
@@ -65,6 +81,7 @@ const { sidebarOpen, sidebarCollapsed, toggleCollapse } = useSidebar()
 
 const isEdit = computed(() => !!route.params.id)
 const saving = ref(false)
+const loading = ref(false)
 const blocks = ref<{ id: string; name: string }[]>([])
 const form = ref({ number: '', blockId: '' })
 const errors = ref<Record<string, string>>({})
@@ -76,12 +93,15 @@ onMounted(async () => {
   } catch {}
 
   if (isEdit.value) {
+    loading.value = true
     try {
       const unit = await unitsService.getById(route.params.id as string)
       form.value.number = unit.number
       form.value.blockId = unit.blockId
     } catch (err) {
       handleError(err, 'Erro ao carregar unidade')
+    } finally {
+      loading.value = false
     }
   }
 })

--- a/apps/web/src/modules/units/pages/UnitsListPage.vue
+++ b/apps/web/src/modules/units/pages/UnitsListPage.vue
@@ -25,7 +25,27 @@
         </div>
 
         <div class="bg-surface-container-lowest rounded-2xl md:rounded-3xl overflow-hidden shadow-sm">
-          <div class="overflow-x-auto">
+          <!-- Loading skeleton -->
+          <div v-if="loading" class="hidden md:block p-8">
+            <div class="space-y-4">
+              <div v-for="n in 4" :key="n" class="flex items-center gap-4 animate-pulse">
+                <div class="h-4 bg-slate-200 rounded w-24" />
+                <div class="h-4 bg-slate-200 rounded w-20" />
+                <div class="flex gap-2">
+                  <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                  <div class="w-8 h-8 bg-slate-200 rounded-lg" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Mobile spinner -->
+          <div v-if="loading" class="md:hidden p-8 text-center text-slate-400">
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto" />
+            <p class="mt-2">Carregando...</p>
+          </div>
+
+          <div v-if="!loading" class="overflow-x-auto">
             <table class="w-full">
               <thead class="bg-surface-container-low">
                 <tr>


### PR DESCRIPTION
Adds animated pulse skeleton placeholders (desktop) and spinner (mobile) to all pages that fetch API data, following the pattern from CommonAreasPage.

Pages updated:
- Admin: Dashboard, Reservations, Announcements, Reports, Settings, CommonAreas (form + list), Blocks (list + form)
- Resident: Dashboard, MyReservations, Announcements, CommonAreaDetail, NewReservation, Availability
- Residents: List, Form, Detail
- Units: List, Form

Also fixes select dropdown arrow overlap by adding appearance-none + pr-8 to all <select> elements across the app.